### PR TITLE
Suppress the integrated PowerShell for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -107,6 +107,7 @@
   "powermode.enabled": true,
   "powermode.enableShake": false,
   "powermode.presets": "particles",
+  "powershell.integratedConsole.showOnStartup": false,
   "powershell.powerShellDefaultVersion": "PowerShell Core 6 (x64)",
   "prettier.htmlWhitespaceSensitivity": "strict",
   "prettier.eslintIntegration": true,


### PR DESCRIPTION
When used in combination with posh-git, Confirmed the problem that crashes when linefeed at the right end.
