### PR TITLE
Fixed a bug that fails for the update command

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -21,4 +21,5 @@ upgrade_node 12
 
 npm upgrade -g
 npm install -g npm
-npm install -g @aws-amplify/cli exp serverless yarn
+npm install -g exp serverless yarn
+npm install -g --no-optional @aws-amplify/cli


### PR DESCRIPTION
The reason is that installation of the optional dependency package of `@aws-amplify/cli` failed.