### PR TITLE
docs(idd): record confirmed IDD policy decisions in docs/idd-policy.md

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -1,0 +1,160 @@
+# IDD Policy Configuration
+
+This repository uses the Issue-Driven Development (IDD) workflow
+imported from
+[`kurone-kito/idd-skill`](https://github.com/kurone-kito/idd-skill).
+This page records the eleven policy decisions confirmed during the
+onboarding flow (roadmap #95). The machine-readable mirror lives at
+[`.github/idd/config.json`](../.github/idd/config.json); keep both in
+sync when the policy changes.
+
+The schema name for each field below comes from
+[`docs/onboarding/policy-decisions.md`](./onboarding/policy-decisions.md)
+so future IDD sessions can navigate between the human-readable record
+and the upstream template without surprises.
+
+## Merge Policy
+
+**Policy**: `fully_autonomous_merge`
+
+One trusted agent session may continue through the F2.5 / F3 handoff
+gate after the normal claim, freshness, CI, advisory, and review gates
+pass. The repository is single-maintainer, so worker credentials and
+merge-capable credentials are intentionally the same scope; see the
+[Credential Scope](#credential-scope) section for the explicit
+boundary.
+
+## PR Review Policy
+
+**Profile**: `copilot-advisory` (distributed default).
+
+GitHub Copilot is requested after review-fix pushes and before merge
+freshness checks; it provides advisory state only. The repository
+already wires CodeRabbit through
+[`.coderabbit.yaml`](../.coderabbit.yaml) — both reviewers coexist.
+Confirm Copilot Code Review is enabled in repository settings before
+the first unattended run; if it is not, migrate to the `external-bot`
+profile pointed at CodeRabbit and follow the edit-surface checklist
+in [`docs/idd-review-policy-profiles.md`](./idd-review-policy-profiles.md).
+
+## Review-Thread Resolution Policy
+
+**Policy**: `fast-agent-resolve` (distributed default).
+
+After an agent accepts and fixes feedback, rejects it with a recorded
+rationale, or handles PATH B advisory feedback, the agent may resolve
+the associated thread. This means "the agent acted on the thread", not
+"the reviewer agreed". Suitable for the parallel-IDD goal because it
+keeps the loop high-throughput.
+
+## Critique-Loop Profile
+
+**Profile**: distributed defaults from
+[`docs/policy-constants.md`](./policy-constants.md). No repository
+override.
+
+## Claim Timing
+
+- **`claim-stale-age`**: `12h` (shortened from the `24h` distributed
+  default).
+- **`claim-heartbeat-interval`**: `6h` (shortened from the `12h`
+  distributed default).
+
+Rationale: this repository runs lightweight CI (cspell, markdownlint,
+bats, Pester, lua syntax). Stale-claim takeover cost is low because a
+single maintainer can revalidate quickly, so a tighter clock keeps
+parallel sessions from leaving idle claims sitting around half a day.
+
+## CI Wait Policy
+
+- **`ciWait.runningTimeout`**: `PT10M` (shortened from the `PT30M`
+  distributed default).
+- **`ciWait.generationTimeout`**: `PT10M` (distributed default).
+- **`ciWait.rerunPolicy`**: `rerun-once` (distributed default).
+
+Rationale: the longest CI job in this repo currently finishes in
+~1 minute, so a 10-minute running timeout is generous without
+stretching the loop wait. Keep the rerun policy on `rerun-once` to
+absorb the occasional transient failure without re-running indefinitely.
+
+## Credential Scope
+
+- **Worker credentials**: maintainer-equivalent (`kurone-kito` repo
+  access — read/write to issues, PRs, branches, commits).
+- **Merge-capable credentials**: identical to worker credentials.
+
+The single-maintainer topology intentionally collapses these two
+scopes. Flag this section before any split-authority migration —
+introducing `separate_merge_agent` later would require splitting the
+credential model first.
+
+## Helper Runtime Profile
+
+**Profile**: `ephemeral-npx`.
+
+The discover, suitability, review-snapshot, advisory-wait, and
+pre-merge phases may invoke
+`npx --yes --package <reviewed-helper-spec> idd-helper-bundle-manifest`
+when a reviewed helper spec is available. The companion prerequisite
+issue #96 pins Node.js 24.15.0 via project-local
+[`.tool-versions`](../.tool-versions) / [`.node-version`](../.node-version) /
+[`.nvmrc`](../.nvmrc) so `npx` always resolves in a fresh worktree.
+
+## Issue-Author Approval Gate
+
+- **Gate posture**: `opted-out`.
+- **`skipIssueAuthorApprovalGate`**: `true` (machine-readable mirror in
+  [`.github/idd/config.json`](../.github/idd/config.json)).
+- **`maintainer-approval-actors` policy**:
+  `owners-and-maintainers-only` (recorded for future re-enablement;
+  moot while the gate is opted out).
+- **Approval signals**: not exercised while the gate is opted out.
+- **`approvalSignals.readyLabelName`**: not configured (default `idd:ready`
+  would apply if the gate is re-enabled later).
+- **`approvalSignals.labelFreshnessMode`**: not configured (default
+  `presence-only` would apply if the gate is re-enabled later).
+- **Missing-approval behavior**: gate inactive — explicit-target runs
+  and discovery may proceed without an approval signal.
+
+Rationale: this is a single-maintainer dotfiles repository. The
+issue-author approval gate exists to keep unattended agents from
+auto-picking up issues filed by strangers; with only the maintainer
+filing issues, the gate is overhead. Re-enable it (and create the
+`idd:ready` label) before opening this repository to multi-author
+collaboration.
+
+## Issue-Authoring Companion
+
+- **Status**: `installed` at `.claude/skills/issue-authoring/`.
+- **`issueAuthoring.maxClarificationRounds`**: `3` (distributed
+  default).
+
+The companion drafts IDD-ready issues and roadmaps before the normal
+Discover loop starts. See its
+[bundled contract](../.claude/skills/issue-authoring/references/contract.md)
+for the readiness buckets, output chooser, and approval boundary.
+
+## Open follow-ups
+
+These items were recorded during onboarding as **deferred** or
+**needs-decision**; they do not block the current IDD execution loop
+but should be revisited when the surrounding policy moves.
+
+- _(deferred)_ Add a dedicated `idd-task.yml` issue template under
+  `.github/ISSUE_TEMPLATE/` so future IDD-driven issues use a stable
+  shape. The issue-authoring companion already produces a valid shape
+  without a template.
+- _(deferred)_ Create the `idd:ready` and `status:authoring`
+  repository labels. With the approval gate opted out and publication
+  routed through the user, neither label is exercised on the
+  ready-execution side. Add them only if a stricter posture is
+  adopted later.
+- _(deferred)_ Promote `lint.yml` and `test.yml` to **required status
+  checks** on the `master` branch protection. Today neither workflow
+  is required, so `fully_autonomous_merge` proceeds without a CI gate.
+  Promoting them would tighten the merge floor before any unattended
+  run.
+- _(needs-decision)_ Confirm GitHub Copilot Code Review is enabled
+  for this repository. The default `copilot-advisory` profile waits
+  on Copilot review state; if Copilot is not enabled, migrate to the
+  `external-bot` profile pointed at CodeRabbit.


### PR DESCRIPTION
## Summary

- Adds `docs/idd-policy.md` capturing the eleven IDD policy decisions confirmed during roadmap #95 onboarding, in the section order from upstream `docs/onboarding/policy-decisions.md`.
- Records the **deferred** and **needs-decision** open follow-ups so a single page surfaces both the active state and the still-pending choices.
- Mirrors `.github/idd/config.json` for machine-readable consumption; the entry-file cross-link is left for #100.

Closes #99
Refs #95

## Test plan

- [x] All eleven `###` policy sections exist (Merge / PR Review / Review-Thread Resolution / Critique-Loop / Claim Timing / CI Wait / Credential Scope / Helper Runtime / Issue-Author Approval Gate / Issue-Authoring Companion / Open follow-ups).
- [x] Every value matches the **Confirmed values** appendix in roadmap #95 verbatim (manual diff completed).
- [x] `npx --yes markdownlint-cli2 docs/idd-policy.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml docs/idd-policy.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass.
- [ ] CI — chezmoi-dependent bash tests and Windows-only Pester tests will remain master-baseline failures; no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive policy documentation detailing repository merge strategies, pull request review guidelines, CI/CD configurations, helper runtime profiles, and development decision records with tracked follow-ups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->