### PR TITLE
docs(idd): add IDD workflow section to root agent entry files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -374,6 +374,35 @@ This isolates tests from chezmoi's template engine and
 CI runs both suites on every push and pull request
 (`.github/workflows/test.yml`).
 
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [`docs/idd-workflow.md`](../docs/idd-workflow.md)
+for the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+[`.github/instructions/idd-overview.instructions.md`](./instructions/idd-overview.instructions.md).
+Open the routed phase file manually when the current step changes.
+The execution loop drives Discover → Claim → Work → PR Submit → CI
+Wait → Review Triage → Review Fix → Merge → Loop through GitHub
+Issues; each phase has its own dedicated instruction file under
+`.github/instructions/`.
+
+For the confirmed policy matrix (merge policy, review profile,
+review-thread resolution, critique-loop, claim timing, CI wait,
+credential scope, helper runtime, issue-author approval gate,
+maintainer-approval-actors policy, and the issue-authoring companion
+status), see [`docs/idd-policy.md`](../docs/idd-policy.md). The
+machine-readable mirror lives at
+[`.github/idd/config.json`](./idd/config.json); keep both in sync.
+
+GitHub Copilot Code Review acts as the advisory reviewer under the
+chosen `copilot-advisory` profile, alongside the existing CodeRabbit
+configuration. `excludeAgent: "code-review"` in
+`idd-overview.instructions.md` keeps the heavy operational workflow
+out of Copilot reviewer context; this lightweight file remains the
+primary reviewer-side reference.
+
 ## Guardrails
 
 - **Do not** modify community documents (CODE_OF_CONDUCT, CONTRIBUTING)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,20 @@ Windows CI.
 Ensure submodules are initialized first:
 `git submodule update --init --recursive`
 
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+[`.github/instructions/idd-overview.instructions.md`](.github/instructions/idd-overview.instructions.md).
+Open the routed phase file manually when the current step changes.
+
+For the confirmed policy matrix (merge policy, review profile, claim
+timing, CI wait, helper runtime, and the rest of the eleven
+decisions), see [docs/idd-policy.md](docs/idd-policy.md).
+
 ## Canonical reference
 
 The full, Copilot-first project guidance lives in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,20 @@ Windows CI.
 Ensure submodules are initialized first:
 `git submodule update --init --recursive`
 
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+[`.github/instructions/idd-overview.instructions.md`](.github/instructions/idd-overview.instructions.md).
+Open the routed phase file manually when the current step changes.
+
+For the confirmed policy matrix (merge policy, review profile, claim
+timing, CI wait, helper runtime, and the rest of the eleven
+decisions), see [docs/idd-policy.md](docs/idd-policy.md).
+
 ## Canonical reference
 
 The full, Copilot-first project guidance lives in

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -114,6 +114,20 @@ customize the project's documentation, tooling, and AI guidelines.
 See the full onboarding checklist in
 [.github/copilot-instructions.md](.github/copilot-instructions.md).
 
+## IDD Workflow
+
+This project uses Issue-Driven Development (IDD) with parallel AI
+agents. Start with [docs/idd-workflow.md](docs/idd-workflow.md) for
+the cross-agent entry path and phase routing.
+
+Before starting IDD work, open
+[`.github/instructions/idd-overview.instructions.md`](.github/instructions/idd-overview.instructions.md).
+Open the routed phase file manually when the current step changes.
+
+For the confirmed policy matrix (merge policy, review profile, claim
+timing, CI wait, helper runtime, and the rest of the eleven
+decisions), see [docs/idd-policy.md](docs/idd-policy.md).
+
 ## Canonical reference
 
 The full, Copilot-first project guidance lives in


### PR DESCRIPTION
## Summary

- Adds an `## IDD Workflow` section to `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and `.github/copilot-instructions.md`.
- Each section points to `docs/idd-workflow.md`, `.github/instructions/idd-overview.instructions.md`, and `docs/idd-policy.md`.
- The lightweight entry files share parallel wording (~14 lines each, placed before the existing "Canonical reference" anchor).
- `.github/copilot-instructions.md` carries a slightly denser version (~29 lines, placed between `## Testing` and `## Guardrails`) with an extra note explaining Copilot's advisory-review role under the chosen `copilot-advisory` profile and the `excludeAgent: "code-review"` interaction.

Closes #100
Refs #95

## Test plan

- [x] Every entry file links to `docs/idd-workflow.md` and `docs/idd-policy.md` (`grep -nE 'docs/idd-workflow\.md|docs/idd-policy\.md'` returns 2+ hits per file).
- [x] Every entry file references `.github/instructions/idd-overview.instructions.md`.
- [x] `npx --yes markdownlint-cli2 CLAUDE.md AGENTS.md GEMINI.md .github/copilot-instructions.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml CLAUDE.md AGENTS.md GEMINI.md .github/copilot-instructions.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass.
- [ ] CI — chezmoi-dependent bash tests and Windows-only Pester tests will remain master-baseline failures; no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Issue-Driven Development (IDD) workflow documentation across multiple configuration files, detailing the parallel AI agent process, workflow entry points, phase instructions, and policy guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->