### PR TITLE
chore(template): add idd-task.yml issue form for IDD-driven tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/idd-task.yml
+++ b/.github/ISSUE_TEMPLATE/idd-task.yml
@@ -1,0 +1,76 @@
+---
+name: 🤖 IDD task
+description: 'Issue-Driven Development task — a focused, autonomously claimable unit of work that follows the IDD execution loop'
+labels: idd-task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for opening an IDD-ready task. Issues filed through this
+        form follow the same schema the
+        [`issue-authoring` companion](../../.claude/skills/issue-authoring/SKILL.md)
+        produces, so a fresh IDD discover run can claim and execute
+        them without back-and-forth.
+
+        Before filing, please confirm that this issue:
+
+        - has a clear, repository-local scope
+        - lists objectively verifiable acceptance criteria
+        - does not hide a mid-implementation human decision or
+          credential dependency
+
+        If any of the above is uncertain, draft through the
+        `issue-authoring` skill first and surface the unresolved part
+        as a separate `needs-decision` / `blocked-by-human` issue.
+
+  - type: input
+    id: parent
+    attributes:
+      label: Parent roadmap
+      description: 'Optional reference to the parent roadmap. Use the issue number (e.g. `#107`) or the roadmap-id marker slug (e.g. `post-onboarding-cleanup`). Leave blank for orphan tasks once the repository enables orphan-first scope.'
+      placeholder: '#107'
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: 'Why this task exists. Cite the file, doc, or PR thread that motivates the change.'
+      placeholder: 'The {{file or feature}} currently {{observed state}}. The IDD workflow or a reviewer flagged this on {{PR or thread link}} because {{root cause}}.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_change
+    attributes:
+      label: Proposed change
+      description: 'What the implementing agent should change. Name the concrete file or surface to edit; do not prescribe every line.'
+      placeholder: 'Edit {{path}} so that {{outcome}}. Keep the surrounding {{section}} intact.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: 'Objectively verifiable checks. Use shell commands, grep queries, or test runs where possible. Avoid criteria that depend on subjective human approval.'
+      placeholder: |
+        - `grep -nE '<pattern>' <file>` returns no matches.
+        - `tests/bash/helpers/bats-core/bin/bats tests/bash/` passes unchanged.
+        - The PR description records {{evidence}}.
+    validations:
+      required: true
+
+  - type: textarea
+    id: candidate_files
+    attributes:
+      label: Candidate files
+      description: 'Optional. Files the implementing agent is most likely to touch. Acts as a hint, not an exhaustive list.'
+      placeholder: |
+        - `path/to/file` (edited)
+        - `path/to/other` (read; edit only if the change requires it)
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: 'Optional. Sequencing, parallelism hints, links to upstream context, or anything else a future claimer should know.'


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/idd-task.yml`: a structured GitHub issue form with the schema sections required by the issue-authoring contract (Background / Proposed change / Acceptance criteria) plus optional parent-roadmap reference, candidate-files hint, and free-form notes.
- Auto-applies a new `idd-task` repository label (created separately via `gh label create`) so IDD discover can filter issues created through this path.
- Wording style matches the existing `bug_report.yml` and `feature_request.yml` forms for picker coherence.

Closes #108
Refs #107

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/ISSUE_TEMPLATE/idd-task.yml'))"` parses cleanly.
- [x] Schema sanity: 7 body items (1 markdown intro, 1 input, 5 textareas) with the three required textareas (`Background`, `Proposed change`, `Acceptance criteria`) marked `required: true`.
- [x] `npx --yes cspell --config .cspell.config.yml .github/ISSUE_TEMPLATE/idd-task.yml` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

GPG remains in category-P pinentry-timeout state seen across PRs #102-#106; commit signed via `git commit-ssh` alias (SSH key `id_ed25519-kito.pub`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a GitHub issue template for Issue-Driven Development tasks with a structured form including required fields for background, proposed changes, and acceptance criteria, plus optional sections for candidate files and notes to standardize and improve clarity in issue tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->