### PR TITLE
fix(idd): replace hardcoded main with master across instructions

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -51,17 +51,17 @@ Convergence guardrails:
   redirected by a maintainer.
 - If the critique pass reports zero issues, proceed to E11.
 
-## E11 — Resolve conflicts with main
+## E11 — Resolve conflicts with master
 
-Check for conflicts between the feature branch and `main`. If conflicts
-exist, merge `main` into the feature branch
-(`git fetch origin main && git merge origin/main`), resolve any
+Check for conflicts between the feature branch and `master`. If conflicts
+exist, merge `master` into the feature branch
+(`git fetch origin master && git merge origin/master`), resolve any
 conflicts, and complete the merge.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is
 `CHANGES_REQUESTED`, get explicit operator confirmation before merging
-`main` into the feature branch, as the merge commit will appear in the
+`master` into the feature branch, as the merge commit will appear in the
 PR history.
 
 ## E12 — Lint, test, push
@@ -240,7 +240,7 @@ proceeding to F — do not skip triage.
 - **On failure / code-caused**: fix, run **fix-validate**, commit
   atomically, then return to E11
 - **On failure / infra-flaky or pre-existing** (failure also present on
-  `main`, unrelated to this branch): apply `ciWait.rerunPolicy`
+  `master`, unrelated to this branch): apply `ciWait.rerunPolicy`
   (default `rerun-once`). If it authorizes the current rerun, rerun
   once and resume polling. If the failure persists after that rerun, or
   if the policy is `hold`, post a hold comment on the PR documenting the

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -241,7 +241,7 @@ Otherwise continue to `idd-review-fix.instructions.md`.
 
 After the review loop confirms no PATH A items remain (from E3 or E8),
 check the current branch state before routing to F-phase. This gate uses
-merge-from-`main` (never rebase) when synchronization is required,
+merge-from-`master` (never rebase) when synchronization is required,
 preserving review history on the already-published PR branch.
 
 When helper runtime is enabled, call:
@@ -267,15 +267,15 @@ Route based on `branchState` from the helper (or `mergeable` /
   a PR comment documenting the state and stop. Do not proceed to F-phase
   without confirmed branch-state evidence.
 
-**Sync path** (merge-from-`main`):
+**Sync path** (merge-from-`master`):
 
 1. **Active review gate**: if the PR has unresolved review threads,
    unreplied comments, or any reviewer's latest state is
    `CHANGES_REQUESTED`, get explicit operator confirmation before merging
-   `main` into the feature branch, as the merge commit will appear in the
+   `master` into the feature branch, as the merge commit will appear in the
    PR history.
-2. Merge `main` into the feature branch:
-   `git fetch origin main && git merge origin/main`
+2. Merge `master` into the feature branch:
+   `git fetch origin master && git merge origin/master`
 3. If conflicts arise, resolve them and complete the merge.
 4. Run **post-fix-validate**.
 5. Push the feature branch normally (no force push required for merge

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -9,20 +9,20 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 Before creating, check for local conflicts in this order:
 
-1. Ensure the local `main` branch is up to date and has no local
-   commits. Run this from the primary worktree while on `main`:
+1. Ensure the local `master` branch is up to date and has no local
+   commits. Run this from the primary worktree while on `master`:
 
    ```sh
-   git fetch origin main
-   git log origin/main..main --oneline
+   git fetch origin master
+   git log origin/master..master --oneline
    ```
 
-   If the second command outputs any lines, local `main` has unpushed
-   commits — stop and report, do not force-reset `main`. Otherwise,
+   If the second command outputs any lines, local `master` has unpushed
+   commits — stop and report, do not force-reset `master`. Otherwise,
    fast-forward to origin:
 
    ```sh
-   git merge --ff-only origin/main
+   git merge --ff-only origin/master
    ```
 
 2. Run `git worktree list` — if a worktree for the branch already
@@ -68,7 +68,7 @@ If WorkTrunk is not available, choose the correct case:
 
 | Case                                       | Command                                                                             |
 | ------------------------------------------ | ----------------------------------------------------------------------------------- |
-| Fresh claim                                | `git worktree add <path> -b <branch-name> origin/main`                              |
+| Fresh claim                                | `git worktree add <path> -b <branch-name> origin/master`                            |
 | Takeover — local branch exists             | `git worktree add <path> <branch-name>`                                             |
 | Takeover — remote branch only              | `git fetch origin && git worktree add <path> -b <branch-name> origin/<branch-name>` |
 | Takeover — neither local nor remote (rare) | treat as fresh claim; preserve the inherited branch name                            |


### PR DESCRIPTION
## Summary

- This repository's default branch is `master`, but three imported IDD instruction files still assumed the upstream `main` name. Replace every branch-reference site so a fresh IDD worktree, conflict-resolution flow, and review-fix merge-from sequence all resolve against `origin/master`.
- Files touched: `.github/instructions/idd-work.instructions.md` (B1 pre-checks + worktree operations table), `.github/instructions/idd-review-fix.instructions.md` (E11 conflict resolution + CI rerun note), `.github/instructions/idd-review-triage.instructions.md` (merge-from sync path).
- Total 19 line edits, 0 line additions/deletions on the file count side. One table-cell trailing-padding adjustment in `idd-work.instructions.md` keeps `MD060` happy after the cell content grew by 2 characters.

Closes #113
Refs #111

## Test plan

- [x] `grep -rnE '\borigin/main\b|\bfetch origin main\b|\bmerge origin/main\b' .github/instructions/` returns no matches.
- [x] `grep -rnE '\bmain\b' .github/instructions/idd-work.instructions.md .github/instructions/idd-review-fix.instructions.md .github/instructions/idd-review-triage.instructions.md` returns no matches.
- [x] `npx --yes markdownlint-cli2 .github/instructions/idd-{work,review-fix,review-triage}.instructions.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml .github/instructions/idd-{work,review-fix,review-triage}.instructions.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all development workflow instructions including code review conflict resolution procedures, branch synchronization and triage processes, and local work environment setup to reflect current repository configuration. Changes ensure developers follow consistent practices across review gates, merge operations, feature branch management, and worktree initialization commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->