### PR TITLE
fix(idd): sync claim timing in instructions with config.json

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -72,7 +72,7 @@ set. If the project is in use, the project status must be "not started".
 using the shared claim-state rules:
 
 Use the `claim-stale-age` policy default from `docs/policy-constants.md`
-for these stale checks (distributed default: `24 h`).
+for these stale checks (distributed default: `12 h`).
 
 - No active claim → unclaimed, proceed.
 - Active claim already uses a `{claim-id}` that this current session had
@@ -80,12 +80,12 @@ for these stale checks (distributed default: `24 h`).
   not post a new claim. Continue with that same `{claim-id}`. A token
   first learned by parsing the current issue comments is not enough.
 - Any other active claim whose latest valid `claimed-by` comment has
-  GitHub `created_at` < 24 h → claimed by another live session, even
+  GitHub `created_at` < 12 h → claimed by another live session, even
   when the `agent-id` matches. Return to Discover using the same
   selection mode that produced this target (orphan-first: continue the
   A0-O capable path; roadmap mode: continue the A3-ready path).
 - Any other active claim whose latest valid `claimed-by` comment has
-  GitHub `created_at` ≥ 24 h → stale, proceed with takeover.
+  GitHub `created_at` ≥ 12 h → stale, proceed with takeover.
 
 Only the GitHub `created_at` of the latest **valid** `claimed-by`
 comment in the active claim counts toward the stale calculation.
@@ -99,12 +99,12 @@ the issue as **unclaimed** — proceed as if no claim exists.
 Otherwise, use the latest trusted legacy `claimed-by` comment as a
 **migration-only** decision input:
 
-- Latest trusted legacy claim has GitHub `created_at` < 24 h → claimed
+- Latest trusted legacy claim has GitHub `created_at` < 12 h → claimed
   by another live session, even when the `agent-id` matches. Return to
   Discover using the same selection mode that produced this target
   (orphan-first: continue the A0-O capable path; roadmap mode: continue
   the A3-ready path).
-- Latest trusted legacy claim has GitHub `created_at` ≥ 24 h → stale,
+- Latest trusted legacy claim has GitHub `created_at` ≥ 12 h → stale,
   proceed and replace it with a new-format claim.
 
 The migration claim uses a fresh `{claim-id}` and `supersedes: none`.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -475,7 +475,7 @@ Before selecting from the surviving viable issues, perform an
    - **Fetch the issue** and parse its comments using the shared claim-state
      rules (defined in `idd-claim.instructions.md`).
    - **Detect active non-stale claims**: Use the `claim-stale-age` policy
-     default from `docs/policy-constants.md` (distributed default: `24 h`).
+     default from `docs/policy-constants.md` (distributed default: `12 h`).
      An issue has an **active non-stale claim** if:
      - A trusted `claimed-by` comment exists, and
      - That comment's GitHub `created_at` timestamp is **less than** the
@@ -488,7 +488,7 @@ Before selecting from the surviving viable issues, perform an
      the scan set.
 
    - **Skip stale or unclaimed candidates**: If the latest `claimed-by`
-     comment is stale (≥ 24 h old) or no claim exists, this candidate
+     comment is stale (≥ 12 h old) or no claim exists, this candidate
      **remains eligible**.
 
 3. **Determine selection candidate**: After scanning the top N:

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -71,7 +71,7 @@ unclaimed state are inheritable by the next agent (see
 
 Keep the claim. Post the hold reason and resume condition to the PR or
 issue comment. After re-validating ownership, re-post the claim comment
-with the same `{claim-id}` every 12 h as heartbeat.
+with the same `{claim-id}` every 6 h as heartbeat.
 After posting the hold reason, upsert the digest with the hold phase, the
 blocking condition in `Open blockers`, and the resume condition in
 `Next action`. Long holds still need claim heartbeats; the digest does

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -121,12 +121,12 @@ Ownership timing in this workflow uses the policy defaults
 `docs/policy-constants.md`.
 
 - **Stale**: an active claim whose latest **valid** `claimed-by`
-  comment's GitHub `created_at` is ≥ 24 h ago. Another session may take
+  comment's GitHub `created_at` is ≥ 12 h ago. Another session may take
   it over by posting a fresh `{claim-id}` whose `supersedes:` value is
   that active claim's `{claim-id}`.
 - **Heartbeat**: after re-validating ownership, re-post the claim
-  comment every 12 h while holding or when any phase is expected to
-  exceed 12 h. The latest **valid** `claimed-by` comment for the same
+  comment every 6 h while holding or when any phase is expected to
+  exceed 6 h. The latest **valid** `claimed-by` comment for the same
   `{claim-id}` resets the stale clock. Embed timestamps are ignored;
   only the GitHub `created_at` of the comment itself counts.
 

--- a/.github/instructions/idd-resume-stall.instructions.md
+++ b/.github/instructions/idd-resume-stall.instructions.md
@@ -93,11 +93,11 @@ waives the stale-threshold gate in S3.
 Apply the shared stale rule from `idd-overview.instructions.md` and
 `claim-stale-age` in `docs/policy-constants.md`:
 takeover is allowed only when the active non-owned claim is stale
-(`latest valid claimed-by created_at >= 24h`).
+(`latest valid claimed-by created_at >= 12h`).
 
-- Claim age `< 24h`: **hold and stop**. Keep waiting for the shared
+- Claim age `< 12h`: **hold and stop**. Keep waiting for the shared
   stale threshold.
-- Claim age `>= 24h`: takeover is eligible; continue to S4.
+- Claim age `>= 12h`: takeover is eligible; continue to S4.
 
 ### S4 — Race-safe takeover recheck
 

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -7,7 +7,7 @@ detail on each routing branch, see
 [`docs/idd-resume-detail.md`](../../docs/idd-resume-detail.md).
 
 Resume stale checks use the `claim-stale-age` policy default from
-`docs/policy-constants.md` (distributed default: `24 h`).
+`docs/policy-constants.md` (distributed default: `12 h`).
 
 ## Required Inputs
 
@@ -81,12 +81,12 @@ Evaluate in order; take the first matching row.
 | FH evidence names this session's already-verified `{claim-id}`                                  | STOP — current session is displaced; do not push, comment, resolve, request reviewers, or merge                               |
 | Forced-handoff recovery confirmed (§FH)                                                         | Re-claim via A5 after GitHub reflects handoff; cite evidence in digest `Authoritative by`; → Step 2                           |
 | No new-format claims + legacy `claimed-by` + later trusted `unclaimed-by` (same agent)          | Treat as unclaimed → fresh A5 claim → Step 2                                                                                  |
-| No new-format claims + legacy `claimed-by`, age < 24 h                                          | STOP — not inheritable even if agent-id matches                                                                               |
-| No new-format claims + legacy `claimed-by`, age ≥ 24 h                                          | Migrate via A5 with `supersedes: none`; → Step 2                                                                              |
+| No new-format claims + legacy `claimed-by`, age < 12 h                                          | STOP — not inheritable even if agent-id matches                                                                               |
+| No new-format claims + legacy `claimed-by`, age ≥ 12 h                                          | Migrate via A5 with `supersedes: none`; → Step 2                                                                              |
 | No active claim                                                                                 | Re-claim via A5; → Step 2                                                                                                     |
-| Active non-stale claim (< 24 h, other session)                                                  | STOP — not inheritable even if agent-id matches                                                                               |
-| Active stale claim (≥ 24 h, other session) + branch field starts with `roadmap-audit/`          | Takeover via A5 with `supersedes: <prior-id>`; then re-run A1.5; STOP after roadmap-side effects                              |
-| Active stale claim (≥ 24 h, other session)                                                      | Takeover via A5 with `supersedes: <prior-id>`; → Step 2                                                                       |
+| Active non-stale claim (< 12 h, other session)                                                  | STOP — not inheritable even if agent-id matches                                                                               |
+| Active stale claim (≥ 12 h, other session) + branch field starts with `roadmap-audit/`          | Takeover via A5 with `supersedes: <prior-id>`; then re-run A1.5; STOP after roadmap-side effects                              |
+| Active stale claim (≥ 12 h, other session)                                                      | Takeover via A5 with `supersedes: <prior-id>`; → Step 2                                                                       |
 
 All re-claims, migrations, and takeovers must use A5 race-safe verification
 from `idd-claim.instructions.md`. Forced-handoff recovery never waives the

--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -94,7 +94,7 @@ discovered beneath it. Before any such side effect, coordinate on the
 
 Treat `stale` and `non-stale` in this section using the
 `claim-stale-age` policy default from `docs/policy-constants.md`
-(distributed default: `24 h`).
+(distributed default: `12 h`).
 
 - Roadmap claim ownership gates roadmap-side mutations only. Do not
   treat a non-stale roadmap claim as a global lock over A2/A3 child


### PR DESCRIPTION
## Summary

- Replaces 21 occurrences of `24 h` / `12 h` (and `24h` / `12h` no-space variants) across 7 IDD instruction files so the documented numbers match the policy values stored in `.github/idd/config.json` (`claimTiming.staleAge: PT12H`, `claimTiming.heartbeatInterval: PT6H`).
- Atomic three-pass substitution via a sentinel marker prevents double-rewriting (`24 h` → sentinel → `12 h`, `12 h` → `6 h`, sentinel → `12 h`).
- No other content changed; column widths preserved because `24 h` and `12 h` are the same character count and the `12h` → `6h` shorts only appear in prose, not table cells.

Closes #112
Refs #111

## Test plan

- [x] `grep -rnE '\b24\s*h\b' .github/instructions/` returns no matches.
- [x] `grep -rnE '\b12\s*h\b' .github/instructions/` returns the freshly-substituted (new) `12 h` references; spot-checked at `idd-claim.instructions.md:75` (`distributed default: 12 h`), `idd-overview-core.instructions.md:124` (`≥ 12 h ago`), `idd-resume-stall.instructions.md:96` (`>= 12h`).
- [x] `jq -r '.claimTiming | "\(.staleAge) / \(.heartbeatInterval)"' .github/idd/config.json` returns `PT12H / PT6H`, matching the new instruction text.
- [x] `npx --yes markdownlint-cli2 .github/instructions/idd-{claim,discover,overview-appendix,overview-core,resume-stall,resume,roadmap-audit}.instructions.md` — the only errors flagged are six pre-existing `MD060/table-column-style` rows in `idd-overview-appendix.instructions.md` (the substitution-damaged "Live value vs Template form" table tracked under #117); no new lint errors introduced.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reduced stale-claim threshold from 24 hours to 12 hours, enabling faster claim expiration detection and takeover eligibility.
  * Updated claim heartbeat cadence from every 12 hours to every 6 hours for maintained active claims.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->