### PR TITLE
fix(idd): defer to project signing ladder instead of --no-gpg-sign

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -96,9 +96,30 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-In non-interactive agent or CI environments where GPG pinentry cannot be
-presented, add `--no-gpg-sign` to all `git commit` and `git merge`
-commands to prevent blocking.
+Follow the project signing fallback ladder documented in
+[`.github/copilot-instructions.md`](../../.github/copilot-instructions.md)
+(also mirrored in [`CLAUDE.md`](../../CLAUDE.md),
+[`AGENTS.md`](../../AGENTS.md), and [`GEMINI.md`](../../GEMINI.md)).
+The bounded ladder is at most three signing attempts:
+
+1. **GPG** (attempt 1) — the configured default for plain `git commit`.
+2. **gpg-agent restart + GPG retry** (attempt 2, categories A and U
+   only) — skip this step when `gpgconf` is unavailable, when
+   `gpg-agent` also backs SSH, or in non-interactive CI.
+3. **SSH fallback** (attempt 3, any category) — prefer the
+   `git commit-ssh` alias (and `git tag-ssh` / `git rebase-ssh`) when
+   available; otherwise a transient `git -c gpg.format=ssh -c
+   user.signingkey="<key>" commit -S` invocation. Never write the
+   transient fallback into `~/.gitconfig` or any chezmoi template.
+4. **Unsigned** (final accepted fallback) — only after GPG and SSH
+   have demonstrably failed. Disclose which path was used in the PR
+   description; when unsigned, also disclose the GPG cause, whether
+   the gpg-agent restart was attempted or skipped (and why), and the
+   SSH cause.
+
+Do **not** pass `--no-gpg-sign` unconditionally to bypass this
+ladder. A non-interactive run with a usable SSH key should still
+sign via `git commit-ssh` before falling through to unsigned.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming


### PR DESCRIPTION
## Summary

- Rewrites the `## Commit signing` section in `idd-overview-appendix.instructions.md` to reference the project's bounded signing ladder (GPG → gpg-agent restart → SSH via `git commit-ssh` → unsigned final fallback) instead of unconditionally adding `--no-gpg-sign` to commits and merges.
- Adds explicit cross-links to `.github/copilot-instructions.md` and the three lightweight mirrors (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) so an agent reading only the appendix still lands on the canonical ladder.
- The new text explicitly forbids unconditional `--no-gpg-sign` while still permitting the unsigned fallback once GPG and SSH have demonstrably failed.

Closes #114
Refs #111

## Test plan

- [x] `grep -nE -- '--no-gpg-sign' .github/instructions/idd-overview-appendix.instructions.md` returns exactly one match — inside the new "Do **not** pass …" prohibition clause — and no other instruction file mentions the flag.
- [x] The rewritten section references `.github/copilot-instructions.md` and the three mirrors by relative link.
- [x] `npx --yes cspell --config .cspell.config.yml .github/instructions/idd-overview-appendix.instructions.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [x] Empirical: every signing event in this onboarding chain (PRs #102 through #122) used the ladder via `git commit-ssh` after the configured GPG path timed out at pinentry — the documentation now matches that behavior.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state). This PR's existence is itself evidence that the documented ladder works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit signing guidance with a clearer hierarchical approach: GPG primary, conditional restarts/retries, SSH fallback, and unsigned only after demonstrated failures.
  * Added explicit rules for avoiding unsigned commits and requirement to disclose signing path/causes in PR descriptions when unsigned commits are necessary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->