### PR TITLE
fix(idd): replace idd-skill literals with configured dotfiles prefix

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -11,8 +11,10 @@ roadmap or blocked-by marker.
 
 - Use the prefix documented by the target repository's onboarding or
   IDD instructions.
-- In this source repository the prefix is `idd-skill`, but installed
-  bundles must not assume that value elsewhere.
+- For this repository, the configured prefix is `dotfiles` (see
+  `.github/idd/config.json#markerPrefix`). Installed bundles in other
+  repositories must read the local config rather than copying this
+  value.
 - If the prefix is not discoverable from the repository docs or user
   context, stop and ask instead of emitting a guessed marker.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,7 @@ the loop starts:
 For broad requests, use the optional issue-authoring companion to draft
 a roadmap and focused child issues before starting the execution loop.
 Use task-list links to group active roadmap work. Reserve
-`idd-skill-blocked-by` markers for true sequential dependencies on a
+`dotfiles-blocked-by` markers for true sequential dependencies on a
 separate roadmap.
 
 When a project has genuine parallel tracks or multi-session coordination


### PR DESCRIPTION
## Summary

- `docs/getting-started.md:70` now recommends `dotfiles-blocked-by` (the configured marker prefix) instead of the upstream-source-named `idd-skill-blocked-by`. Without this fix, dependencies authored from the documented snippet would have been invisible to the IDD discover gate, which only resolves the configured prefix.
- `.claude/skills/issue-authoring/references/contract.md:14` no longer hardcodes "the prefix is `idd-skill`". The paragraph now resolves the prefix from `.github/idd/config.json#markerPrefix` and calls out `dotfiles` as the concrete value for this repository, leaving the bundle generic for any future installation in another repo.

Closes #116
Refs #111

## Test plan

- [x] `grep -rnE 'idd-skill-(blocked-by|roadmap-id)' .github/ docs/ .claude/` returns no matches.
- [x] `grep -n 'dotfiles-blocked-by' docs/getting-started.md` matches the substituted line.
- [x] `grep -n 'dotfiles' .claude/skills/issue-authoring/references/contract.md` shows the new prefix-resolution paragraph.
- [x] `npx --yes markdownlint-cli2 docs/getting-started.md .claude/skills/issue-authoring/references/contract.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml docs/getting-started.md .claude/skills/issue-authoring/references/contract.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)