### PR TITLE
fix(idd): repair companion bundle cross-doc links at installed path

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -87,10 +87,14 @@ needs-decision, blocked-by-human, and out-of-scope.
   [references/workflow-boundary.md](references/workflow-boundary.md).
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
-- When editing this bundle inside the source repository, keep the
-  bundled references synchronized with the canonical maintenance docs in
-  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
-  and [../../docs/idd-workflow.md](../../docs/idd-workflow.md).
+- This is an installed companion bundle, not the source-repository
+  copy. When the upstream bundle changes, re-import from the canonical
+  maintenance docs in
+  [`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/issue-authoring-skill.md)
+  and
+  [`kurone-kito/idd-skill:docs/idd-workflow.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/idd-workflow.md);
+  the corresponding in-repo copy of the workflow doc is at
+  [`../../../docs/idd-workflow.md`](../../../docs/idd-workflow.md).
 
 ## Output Checklist
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1,8 +1,9 @@
 # Bundled Issue Authoring Contract
 
 This file keeps the `issue-authoring` bundle usable when it is installed
-or copied outside this repository root. It mirrors the canonical
-contract in `docs/issue-authoring-skill.md`.
+or copied outside its source repository. It mirrors the canonical
+contract maintained upstream at
+[`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/issue-authoring-skill.md).
 
 ## Target marker prefix
 


### PR DESCRIPTION
## Summary

- `.claude/skills/issue-authoring/SKILL.md:92-93` no longer uses `../../docs/...` (which resolved to the non-existent `.claude/skills/docs/`). The "synchronize with canonical maintenance docs" item now points at upstream URLs pinned to commit `b64eab0d51a79bd3199740505f3b7843bc94a0d4` (matching the import baseline) and also surfaces the in-repo `../../../docs/idd-workflow.md` copy.
- The surrounding sentence is rewritten so a reader understands the bundle is an installed copy, not the upstream source — they should re-import from upstream rather than try to edit those maintenance docs from inside the adopter clone.
- `.claude/skills/issue-authoring/references/contract.md:5` no longer refers to the missing `docs/issue-authoring-skill.md` as a local file; it now points at the upstream URL.

Closes #118
Refs #111

## Test plan

- [x] `grep -rn '\.\./\.\.\b\|docs/issue-authoring-skill\.md' .claude/skills/issue-authoring/` returns no broken paths (the only `../..` reference left is the corrected three-level `../../../docs/idd-workflow.md`, which targets an existing file: `ls docs/idd-workflow.md` confirms).
- [x] Both upstream URLs in the rewritten sentences include the same `b64eab0d51a79bd3199740505f3b7843bc94a0d4` commit pin used for the original import (verifiable via `gh api repos/kurone-kito/idd-skill/contents/docs/issue-authoring-skill.md?ref=b64eab0d51a79bd3199740505f3b7843bc94a0d4` returning a non-404).
- [x] `npx --yes markdownlint-cli2 .claude/skills/issue-authoring/SKILL.md .claude/skills/issue-authoring/references/contract.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml .claude/skills/issue-authoring/SKILL.md .claude/skills/issue-authoring/references/contract.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the issue-authoring skill is an installed companion bundle.
  * Updated guidance to reference upstream maintenance-documentation URLs for bundle content updates.
  * Added direct link to the canonical upstream issue-authoring contract documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->