### PR TITLE
fix(idd): pin ephemeral-npx helper to import-baseline commit

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -79,9 +79,15 @@ from the target repository root to get the concrete import surface for
 the chosen profile:
 
 ```sh
-npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main \
-  idd-helper-bundle-manifest --profile package-manager
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/b64eab0d51a79bd3199740505f3b7843bc94a0d4 \
+  idd-helper-bundle-manifest --profile ephemeral-npx
 ```
+
+The tarball URL is pinned to the same upstream commit used as the
+import baseline for this repository's IDD instructions and companion
+bundle, so the helper code never drifts ahead of the checked-in
+phase docs. Replace `--profile ephemeral-npx` with the profile your
+repository actually configured if it differs.
 
 The manifest auto-detects npm, pnpm, or yarn from the target repository
 when possible. If detection is ambiguous, pass this flag explicitly:

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -93,12 +93,22 @@ credential model first.
 **Profile**: `ephemeral-npx`.
 
 The discover, suitability, review-snapshot, advisory-wait, and
-pre-merge phases may invoke
-`npx --yes --package <reviewed-helper-spec> idd-helper-bundle-manifest`
-when a reviewed helper spec is available. The companion prerequisite
-issue #96 pins Node.js 24.15.0 via project-local
-[`.tool-versions`](../.tool-versions) / [`.node-version`](../.node-version) /
-[`.nvmrc`](../.nvmrc) so `npx` always resolves in a fresh worktree.
+pre-merge phases may invoke the helper manifest via:
+
+```sh
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/b64eab0d51a79bd3199740505f3b7843bc94a0d4 \
+  idd-helper-bundle-manifest --profile ephemeral-npx
+```
+
+The tarball URL is pinned to the same upstream commit used as the
+import baseline for `.github/instructions/` and `.claude/skills/`, so
+the helper surface never drifts ahead of the checked-in templates.
+Bump that commit deliberately whenever the IDD instructions are
+re-imported; do **not** point the spec at a mutable `refs/heads/main`
+ref. The companion prerequisite #96 pins Node.js 24.15.0 via
+project-local [`.tool-versions`](../.tool-versions) /
+[`.node-version`](../.node-version) / [`.nvmrc`](../.nvmrc) so `npx`
+always resolves in a fresh worktree.
 
 ## Issue-Author Approval Gate
 


### PR DESCRIPTION
## Summary

Takes **option 1** from #115:

- `docs/customization.md:82-83` worked example now pulls the helper from `https://codeload.github.com/kurone-kito/idd-skill/tar.gz/b64eab0d51a79bd3199740505f3b7843bc94a0d4` (the same upstream commit used as the import baseline in #97 / #98), with `--profile ephemeral-npx` matching the chosen `helperRuntime.profile`.
- `docs/idd-policy.md:96-101` Helper Runtime Profile section now carries the full worked invocation (replacing the `<reviewed-helper-spec>` placeholder) plus an explicit prohibition: do **not** repoint the spec at the mutable `refs/heads/main` ref; bump the commit deliberately at re-import time.

This keeps the helper surface from drifting ahead of the checked-in IDD instruction templates, which is what makes the `ephemeral-npx` profile safe to use unattended.

Closes #115
Refs #111

## Test plan

- [x] `grep -rn 'refs/heads/main' docs/` returns only the new explicit prohibition line in `idd-policy.md` (no remaining worked example uses the mutable ref).
- [x] `grep -rn 'reviewed-helper-spec' docs/` returns no matches.
- [x] Both worked invocations include `--profile ephemeral-npx`.
- [x] The pinned commit `b64eab0d51a79bd3199740505f3b7843bc94a0d4` matches the `?ref=` parameter used for the original IDD template fetches (cross-checkable in PR #103 and #104 descriptions).
- [x] `npx --yes markdownlint-cli2 docs/customization.md docs/idd-policy.md` → 0 errors.
- [x] `npx --yes cspell --config .cspell.config.yml docs/customization.md docs/idd-policy.md` → 0 issues.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally.
- [ ] CI — chezmoi-dependent Bash tests and Windows-only Pester tests remain master-baseline failures (tracked under #109 / #110); no new regressions expected.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)