### PR TITLE
fix(ci): install chezmoi in bash tests workflow job

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -39,6 +39,7 @@ words:
   - inputrc
   - keepassxc
   - kito
+  - luac
   - luks
   - psmux
   - pylint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Install chezmoi
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+      - name: Install chezmoi and zsh
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zsh
       - name: Ensure chezmoi on PATH
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run bats tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+      - name: Ensure chezmoi on PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run bats tests
         run: tests/bash/helpers/bats-core/bin/bats tests/bash/
 


### PR DESCRIPTION
## Summary

- Adds two CI steps to `.github/workflows/test.yml`'s `bash-tests` job: install `chezmoi` into `$HOME/.local/bin` via the official one-shot installer, then append that directory to `$GITHUB_PATH` so `Run bats tests` resolves the binary on `PATH`.
- The bats suite invokes `chezmoi execute-template` indirectly via per-test `_render()` helpers (`tests/bash/signing-resolve.bats:20-26`, `tests/bash/secret-deploy-manifest.bats:20-26`). The ubuntu-latest runner did not preinstall chezmoi, so each `_render` call exited 127 and the failures were environmental, not behavioral. After this fix the suite should run end to end.
- Post-merge follow-up (not in this commit): once `master`'s `Bash tests (bats)` check is green, append `Bash tests (bats)` to `required_status_checks.contexts` via `gh api PUT branches/master/protection`. This is a settings-only update and can be done by the same session that watches the post-merge run.

Closes #109
Refs #107

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` parses cleanly.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` → 212 / 212 pass locally (where `chezmoi` is already on `PATH` via Homebrew).
- [ ] PR CI: `Bash tests (bats)` should now complete green. This is the empirical verification the issue acceptance criteria require.
- [ ] Post-merge: branch-protection update to add `Bash tests (bats)` to required checks. Will be applied by the same agent session that watches the post-merge `master` run.

## Signing trail

Commit signed via `git commit-ssh` alias (SSH fallback path; GPG remained in category-P pinentry timeout state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)