### PR TITLE
docs(ai-strategy): document the user-global instructions layer

### DIFF
--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -17,6 +17,30 @@ in this template.
 - [GEMINI.md](../GEMINI.md) is a Gemini CLI compatibility entry point
   with the same role.
 
+## User-global instructions
+
+In addition to the project-level layer above, this repository ships
+a **user-global** instructions layer via chezmoi. Each supported AI
+CLI reads one file from the user's home directory before loading any
+repository-specific instructions:
+
+| Agent              | Chezmoi source                                 | Deployed to                          |
+| ------------------ | ---------------------------------------------- | ------------------------------------ |
+| GitHub Copilot CLI | `home/dot_copilot/copilot-instructions.md`     | `~/.copilot/copilot-instructions.md` |
+| Codex CLI          | `home/dot_codex/AGENTS.md`                     | `~/.codex/AGENTS.md`                 |
+| Claude Code        | `home/dot_claude/CLAUDE.md`                    | `~/.claude/CLAUDE.md`                |
+| Gemini CLI         | `home/dot_gemini/GEMINI.md`                    | `~/.gemini/GEMINI.md`                |
+
+**Precedence rule**: project-level instructions always take
+precedence over the user-global file. Each user-global file opens
+with an explicit deference paragraph stating this rule.
+
+The user-global layer is repository-independent and intentionally
+smaller than the canonical `.github/copilot-instructions.md`. It
+carries the five sections that need to be available in any
+repository: conversation language policy, Conventional Commits,
+signing fallback ladder, coding standards, and guardrails.
+
 ## Change policy
 
 - Prefer preserving existing Copilot behavior over abstracting too
@@ -34,5 +58,7 @@ in this template.
 - Treat this file as a human-facing strategy note, not as the primary
   instruction file for any agent.
 - When updating AI guidance, review `README.md`,
-  `.github/copilot-instructions.md`, `AGENTS.md`, `CLAUDE.md`, and
-  `GEMINI.md` together.
+  `.github/copilot-instructions.md`, `AGENTS.md`, `CLAUDE.md`,
+  `GEMINI.md`, and the four user-global source files under
+  `home/dot_copilot/`, `home/dot_codex/`, `home/dot_claude/`,
+  and `home/dot_gemini/` together.

--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -37,9 +37,10 @@ with an explicit deference paragraph stating this rule.
 
 The user-global layer is repository-independent and intentionally
 smaller than the canonical `.github/copilot-instructions.md`. It
-carries the five sections that need to be available in any
-repository: conversation language policy, Conventional Commits,
-signing fallback ladder, coding standards, and guardrails.
+carries four sections available in any repository: Conversation
+(language matching and autonomous/pause behavior), Commit rules
+(Conventional Commits format and the bounded signing fallback
+ladder), Coding standards, and Guardrails.
 
 ## Change policy
 


### PR DESCRIPTION
## Summary

Updates `docs/ai-strategy.md` to document the user-global
instructions layer introduced across the symmetrization roadmap
(#130). Adds a new section naming the four chezmoi source paths
(`home/dot_copilot/`, `home/dot_codex/`, `home/dot_claude/`,
`home/dot_gemini/`), their chezmoi deploy targets, the precedence
rule (project > user-global), and the user-global layer's
repository-independent, intentionally smaller scope. Extends
"Maintenance notes" to include the `home/dot_<agent>/…` files in
the set that should be reviewed together when AI guidance changes.

Closes #134
Roadmap #130

## Test plan

- [x] `npx markdownlint-cli2 "docs/ai-strategy.md"` — 0 errors
- [x] `npx cspell docs/ai-strategy.md` — 0 issues
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 212/212
- [x] `pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` — 182 passed, 0 failed, 33 skipped
- [ ] Lint + Test workflow on this PR — CI green on required checks

## Signing path

GPG attempt 1 (category **P** pinentry). Routed to `git commit-ssh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how user-global AI instruction files are used alongside project-specific guidance and established the precedence rule (project overrides user-global).
  * Documented which supported AI CLIs read corresponding user-home instruction files before repo-specific guidance.
  * Expanded maintenance notes to list all related user-global and project-level instruction sources to review together.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/dotfiles/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->