### PR TITLE
tweak the npm package configuration for claude-code

### DIFF
--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -3,7 +3,7 @@ dotnet = "latest"
 node = "latest"
 pnpm = "latest"
 
-"npm:@anthropic-ai/claude-code" = "latest"
+"npm:@anthropic-ai/claude-code" = { version = "latest", npm_args = "--ignore-scripts=false" }
 "npm:@bitwarden/cli" = "latest"
 "npm:@executeautomation/playwright-mcp-server" = "latest"
 "npm:@github/copilot" = "latest"


### PR DESCRIPTION
Since the `postinstall` lifecycle is disabled in the latest version of npm, some workarounds are required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Claude Code installation settings to ensure required npm post-install scripts run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->