### PR TITLE
fix(git): remove relative core.excludesFile breaking global gitignore

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -58,4 +58,4 @@ words:
   - xclip
   - zcompdump
   - zdharma
-  - zdiff
+  - zdiff3

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -54,6 +54,8 @@ words:
   - wgetrc
   - viml
   - virtiofs
+  - WORKFPR
   - xclip
   - zcompdump
   - zdharma
+  - zdiff

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -89,7 +89,6 @@
   compression = 9
   editor = nvim
   eol = lf
-  excludesfile = ./ignore
   longpaths = true
   precomposeUnicode = true
   quotepath = false

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -100,6 +100,13 @@ JSON
   refute_output --partial 'signingkey = "FPR"'
 }
 
+@test "config: no relative excludesfile value is emitted" {
+  echo '{ "data": {} }' > "$TMP_CFG"
+  run _render "$CONFIG_TMPL"
+  assert_success
+  refute_output --partial 'excludesfile'
+}
+
 @test "config: legacy primary_signing field is rejected with rename hint" {
   cat > "$TMP_CFG" <<'JSON'
 { "data": { "secret": { "ssh": { "keys": {

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -100,10 +100,11 @@ JSON
   refute_output --partial 'signingkey = "FPR"'
 }
 
-@test "config: no relative excludesfile value is emitted" {
+@test "config: no excludesfile key (relative or otherwise) is emitted" {
   echo '{ "data": {} }' > "$TMP_CFG"
   run _render "$CONFIG_TMPL"
   assert_success
+  run tr '[:upper:]' '[:lower:]' <<< "$output"
   refute_output --partial 'excludesfile'
 }
 

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -104,6 +104,7 @@ JSON
   echo '{ "data": {} }' > "$TMP_CFG"
   run _render "$CONFIG_TMPL"
   assert_success
+  assert_output --partial '[core]'
   run tr '[:upper:]' '[:lower:]' <<< "$output"
   assert_success
   refute_output --partial 'excludesfile'

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -105,6 +105,7 @@ JSON
   run _render "$CONFIG_TMPL"
   assert_success
   run tr '[:upper:]' '[:lower:]' <<< "$output"
+  assert_success
   refute_output --partial 'excludesfile'
 }
 


### PR DESCRIPTION
## Summary

`core.excludesFile = ./ignore` in `home/dot_config/git/config.tmpl`
resolves relative to the current working directory, not the config
file. Setting it explicitly also overrides git's XDG default
(`~/.config/git/ignore`), so the chezmoi-deployed global gitignore has
never actually been in effect — worse, running git from any directory
containing a file literally named `ignore` would silently use that
file as the global excludes.

- Removed the `excludesfile = ./ignore` line. Git ≥ 1.7.12 already
  reads `$XDG_CONFIG_HOME/git/ignore` (default
  `~/.config/git/ignore`) when `core.excludesFile` is unset, and
  chezmoi deploys the ignore file to exactly that path.
- Searched the template surface for other relative-path config values
  with the same failure mode (e.g. `attributesfile`) — none found.
- Added a bats assertion to `tests/bash/signing-resolve.bats` (the
  existing suite that renders `config.tmpl` via chezmoi
  `execute-template`) so a relative `excludesfile` value cannot be
  silently reintroduced.

Closes #152

## Functional evidence

Rendered the template with an empty config, installed it as
`~/.config/git/config` in an isolated `HOME`/`XDG_CONFIG_HOME`, added
a pattern to `~/.config/git/ignore` that exists nowhere else, then
ran `git check-ignore` from a fresh repo outside any tree shipping
that pattern:

```text
$ HOME=<tmp> XDG_CONFIG_HOME=<tmp>/.config git check-ignore -v foo.mysecret
<tmp>/.config/git/ignore:1:*.mysecret	foo.mysecret
```

The pattern is matched only via the global ignore file, confirming the
fix restores the intended behavior.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 213/213
      passing, including the new assertion
- [x] Manual functional verification (see above)
- [ ] CI (Windows PowerShell Pester leg not run locally — no
      PowerShell files touched by this change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the default Git `excludesfile` setting from generated configuration, preventing unintended ignore-file behavior.

* **Tests**
  * Added a new test to verify the `[core]` block is present while `excludesfile` remains absent even with empty input data.

* **Documentation**
  * Updated the spell-check allowlist to include `WORKFPR` and `zdiff3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->