### PR TITLE
fix(ssh): preserve foreign authorized_keys entries via managed block

### DIFF
--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -1,6 +1,9 @@
 #!/usr/bin/env pwsh
 # chezmoi run_onchange_after script: Generate ~/.ssh/authorized_keys
 # from deployed public key files. Re-runs when SSH key config changes.
+# Only the managed block below is owned by this script; every line
+# outside it (e.g. keys added via ssh-copy-id or a cloud provider) is
+# preserved across regeneration.
 $ErrorActionPreference = 'Stop'
 
 {{ $sshKeys := dig "secret" "ssh" "keys" dict . -}}
@@ -11,26 +14,58 @@ exit 0
 
 $sshDir = Join-Path $HOME '.ssh'
 $authorized = Join-Path $sshDir 'authorized_keys'
+$beginMarker = '# >>> chezmoi managed keys >>>'
+$endMarker = '# <<< chezmoi managed keys <<<'
 
 New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
 
-$lines = @()
+$managedLines = @()
 
 {{ range $key, $sshKey := $sshKeys -}}
 $pubFile = Join-Path $sshDir '{{ $sshKey.filename }}.pub'
 if (Test-Path $pubFile) {
-  $lines += (Get-Content -Path $pubFile -Raw).TrimEnd()
+  $managedLines += (Get-Content -Path $pubFile -Raw).TrimEnd()
   Write-Host '  Added {{ $sshKey.filename }}.pub'
 } else {
   Write-Host '  Skipped {{ $sshKey.filename }}.pub (not found)'
 }
 {{ end -}}
 
-if ($lines.Count -eq 0) {
-  Write-Warning 'No public keys were found; authorized_keys will be empty.'
+if ($managedLines.Count -eq 0) {
+  Write-Warning 'No public keys were found; managed block will be empty.'
 }
 
-$lines -join "`n" | Set-Content -Path $authorized -Encoding utf8NoBOM -NoNewline
+$existingLines = @()
+if (Test-Path $authorized) {
+  $existingLines = @(Get-Content -Path $authorized)
+}
+
+$beginIndex = [array]::IndexOf($existingLines, $beginMarker)
+$endIndex = [array]::IndexOf($existingLines, $endMarker)
+
+$outLines = @()
+if ($beginIndex -ge 0 -and $endIndex -gt $beginIndex) {
+  # Replace the existing managed block in place, preserving every
+  # line outside it.
+  if ($beginIndex -gt 0) {
+    $outLines += $existingLines[0..($beginIndex - 1)]
+  }
+  $outLines += $beginMarker
+  $outLines += $managedLines
+  $outLines += $endMarker
+  if ($endIndex + 1 -lt $existingLines.Count) {
+    $outLines += $existingLines[($endIndex + 1)..($existingLines.Count - 1)]
+  }
+} else {
+  # No managed block yet: preserve any existing (foreign) content and
+  # append a fresh managed block.
+  $outLines += $existingLines
+  $outLines += $beginMarker
+  $outLines += $managedLines
+  $outLines += $endMarker
+}
+
+($outLines -join "`n") + "`n" | Set-Content -Path $authorized -Encoding utf8NoBOM -NoNewline
 
 # Keep the file private, but still readable by the LocalSystem sshd
 # service when Windows OpenSSH is configured to use per-user keys.

--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -43,19 +43,32 @@ if (Test-Path $authorized) {
 
 $beginCount = ($existingLines | Where-Object { $_ -eq $beginMarker }).Count
 $endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
-$beginIndex = [array]::IndexOf($existingLines, $beginMarker)
-$endIndex = [array]::IndexOf($existingLines, $endMarker)
-$hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 $markersPresent = ($beginCount -gt 0) -or ($endCount -gt 0)
+# A "shaped" block is exactly one begin and one end marker. Anything
+# else (missing end marker, duplicated markers left behind by a prior
+# malformed run) is flagged every run until an operator cleans it up,
+# even once a valid pair below is found to update in place.
+$blockShapeOk = ($beginCount -eq 1) -and ($endCount -eq 1)
 
-if ($markersPresent -and -not $hasValidBlock) {
-  Write-Warning "Malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+# Locate the last begin marker and the first end marker after it, so a
+# block appended by a prior malformed-recovery run is found and
+# updated in place on the next run instead of appending yet another
+# block (which would never converge).
+$beginIndex = [array]::LastIndexOf($existingLines, $beginMarker)
+$endIndex = -1
+if ($beginIndex -ge 0) {
+  $endIndex = [array]::IndexOf($existingLines, $endMarker, $beginIndex + 1)
+}
+$hasValidBlock = ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
+
+if ($markersPresent -and -not $blockShapeOk) {
+  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
 }
 
 $outLines = @()
 if ($hasValidBlock) {
-  # Replace the existing managed block in place, preserving every
-  # line outside it.
+  # Replace the last managed block in place, preserving every line
+  # outside it.
   if ($beginIndex -gt 0) {
     $outLines += $existingLines[0..($beginIndex - 1)]
   }
@@ -66,11 +79,14 @@ if ($hasValidBlock) {
     $outLines += $existingLines[($endIndex + 1)..($existingLines.Count - 1)]
   }
 } else {
-  # No managed block yet, or the existing markers are malformed
-  # (missing/duplicated): preserve any existing content as-is and
-  # append a fresh managed block rather than risk dropping foreign
-  # lines by guessing at a broken block's boundaries.
-  $outLines += $existingLines
+  # No managed block yet, or no end marker follows any begin marker:
+  # preserve any existing content and append a fresh managed block
+  # rather than risk dropping foreign lines by guessing at a broken
+  # block's boundaries. Exception: when migrating from the
+  # pre-managed-block script (an unmarked file already containing the
+  # same key lines we are about to manage), drop those exact-duplicate
+  # lines so the first managed run doesn't double them up.
+  $outLines += $existingLines | Where-Object { $managedLines -notcontains $_ }
   $outLines += $beginMarker
   $outLines += $managedLines
   $outLines += $endMarker

--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -8,10 +8,6 @@
 $ErrorActionPreference = 'Stop'
 
 {{ $sshKeys := dig "secret" "ssh" "keys" dict . -}}
-{{ if not $sshKeys -}}
-Write-Host 'No SSH keys configured; skipping authorized_keys generation.'
-exit 0
-{{ end -}}
 
 $sshDir = Join-Path $HOME '.ssh'
 $authorized = Join-Path $sshDir 'authorized_keys'

--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -62,7 +62,7 @@ if ($beginIndex -ge 0) {
 $hasValidBlock = ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 
 if ($markersPresent -and -not $blockShapeOk) {
-  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
+  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. A valid block will be updated in place if one can be found, otherwise a fresh block is appended."
 }
 
 $outLines = @()

--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -40,11 +40,14 @@ if (Test-Path $authorized) {
   $existingLines = @(Get-Content -Path $authorized)
 }
 
+$beginCount = ($existingLines | Where-Object { $_ -eq $beginMarker }).Count
+$endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
 $beginIndex = [array]::IndexOf($existingLines, $beginMarker)
 $endIndex = [array]::IndexOf($existingLines, $endMarker)
+$hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 
 $outLines = @()
-if ($beginIndex -ge 0 -and $endIndex -gt $beginIndex) {
+if ($hasValidBlock) {
   # Replace the existing managed block in place, preserving every
   # line outside it.
   if ($beginIndex -gt 0) {
@@ -57,8 +60,10 @@ if ($beginIndex -ge 0 -and $endIndex -gt $beginIndex) {
     $outLines += $existingLines[($endIndex + 1)..($existingLines.Count - 1)]
   }
 } else {
-  # No managed block yet: preserve any existing (foreign) content and
-  # append a fresh managed block.
+  # No managed block yet, or the existing markers are malformed
+  # (missing/duplicated): preserve any existing content as-is and
+  # append a fresh managed block rather than risk dropping foreign
+  # lines by guessing at a broken block's boundaries.
   $outLines += $existingLines
   $outLines += $beginMarker
   $outLines += $managedLines

--- a/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.ps1.tmpl
@@ -3,7 +3,8 @@
 # from deployed public key files. Re-runs when SSH key config changes.
 # Only the managed block below is owned by this script; every line
 # outside it (e.g. keys added via ssh-copy-id or a cloud provider) is
-# preserved across regeneration.
+# preserved across regeneration, though line endings and a missing
+# trailing newline may be normalized in the process.
 $ErrorActionPreference = 'Stop'
 
 {{ $sshKeys := dig "secret" "ssh" "keys" dict . -}}
@@ -45,6 +46,11 @@ $endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
 $beginIndex = [array]::IndexOf($existingLines, $beginMarker)
 $endIndex = [array]::IndexOf($existingLines, $endMarker)
 $hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
+$markersPresent = ($beginCount -gt 0) -or ($endCount -gt 0)
+
+if ($markersPresent -and -not $hasValidBlock) {
+  Write-Warning "Malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+}
 
 $outLines = @()
 if ($hasValidBlock) {

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -43,47 +43,83 @@ if [ ! -s "${managed_keys}" ]; then
   echo "  WARNING: no public keys were found; managed block will be empty."
 fi
 
-has_valid_block=false
-markers_present=false
+begin_count=0
+end_count=0
 if [ -f "${authorized}" ]; then
-  begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
-  end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
-  if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
-    markers_present=true
-  fi
-  if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
-    begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
-    end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
-    if [ "${begin_line}" -lt "${end_line}" ]; then
-      has_valid_block=true
-    fi
-  fi
+  begin_count=$(grep -cFx "${begin_marker}" "${authorized}" || true)
+  end_count=$(grep -cFx "${end_marker}" "${authorized}" || true)
 fi
 
-if [ "${markers_present}" = true ] && [ "${has_valid_block}" = false ]; then
-  echo "  WARNING: malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+markers_present=false
+if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
+  markers_present=true
+fi
+
+# A "shaped" block is exactly one begin and one end marker. Anything
+# else (missing end marker, duplicated markers left behind by a prior
+# malformed run) is flagged every run until an operator cleans it up,
+# even once a valid pair below is found to update in place.
+block_shape_ok=false
+if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
+  block_shape_ok=true
+fi
+
+# Locate the last begin marker and the first end marker after it, so a
+# block appended by a prior malformed-recovery run is found and
+# updated in place on the next run instead of appending yet another
+# block (which would never converge).
+begin_line=""
+end_line=""
+if [ -f "${authorized}" ]; then
+  begin_line=$(grep -nFx "${begin_marker}" "${authorized}" | tail -1 | cut -d: -f1 || true)
+  if [ -n "${begin_line}" ]; then
+    end_line=$(awk -v b="${begin_line}" -v end="${end_marker}" 'NR > b && $0 == end { print NR; exit }' "${authorized}")
+  fi
+fi
+has_valid_block=false
+if [ -n "${begin_line}" ] && [ -n "${end_line}" ]; then
+  has_valid_block=true
+fi
+
+if [ "${markers_present}" = true ] && [ "${block_shape_ok}" = false ]; then
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
 fi
 
 if [ "${has_valid_block}" = true ]; then
-  # Replace the existing managed block in place, preserving every
-  # line outside it.
-  awk -v begin="${begin_marker}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
-    $0 == begin {
+  # Replace the last managed block in place, preserving every line
+  # outside it.
+  awk -v begin_line="${begin_line}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
+    NR == begin_line {
       print
       while ((getline line < keysfile) > 0) print line
       in_block = 1
       next
     }
-    $0 == end { in_block = 0 }
-    !in_block { print }
+    in_block && $0 == end {
+      print
+      in_block = 0
+      next
+    }
+    in_block { next }
+    { print }
   ' "${authorized}" > "${new_file}"
 else
-  # No managed block yet, or the existing markers are malformed
-  # (missing/duplicated): preserve any existing content as-is and
-  # append a fresh managed block rather than risk dropping foreign
-  # lines by guessing at a broken block's boundaries.
+  # No managed block yet, or no end marker follows any begin marker:
+  # preserve any existing content and append a fresh managed block
+  # rather than risk dropping foreign lines by guessing at a broken
+  # block's boundaries. Exception: when migrating from the
+  # pre-managed-block script (an unmarked file already containing the
+  # same key lines we are about to manage), drop those exact-duplicate
+  # lines so the first managed run doesn't double them up.
   if [ -f "${authorized}" ]; then
-    cat "${authorized}" > "${new_file}"
+    if [ -s "${managed_keys}" ]; then
+      non_empty_managed_keys="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
+      trap 'rm -f "${managed_keys}" "${new_file}" "${non_empty_managed_keys}"' EXIT
+      grep -v '^$' "${managed_keys}" > "${non_empty_managed_keys}" || true
+      grep -vFxf "${non_empty_managed_keys}" "${authorized}" > "${new_file}" || true
+    else
+      cat "${authorized}" > "${new_file}"
+    fi
     if [ -s "${new_file}" ] && [ "$(tail -c1 "${new_file}")" != "" ]; then
       printf '\n' >> "${new_file}"
     fi

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -3,8 +3,8 @@
 # from deployed public key files. Re-runs when SSH key config changes.
 # Only the managed block below is owned by this script; every line
 # outside it (e.g. keys added via ssh-copy-id or a cloud provider) is
-# preserved across regeneration (a missing trailing newline may be
-# added when a fresh block is first appended).
+# preserved across regeneration, though a missing trailing newline may
+# be normalized in the process.
 set -euo pipefail
 
 # See run_after_99-secret-status-summary.sh.tmpl for rationale.
@@ -44,9 +44,13 @@ if [ ! -s "${managed_keys}" ]; then
 fi
 
 has_valid_block=false
+markers_present=false
 if [ -f "${authorized}" ]; then
   begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
   end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
+  if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
+    markers_present=true
+  fi
   if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
     begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
     end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
@@ -54,6 +58,10 @@ if [ -f "${authorized}" ]; then
       has_valid_block=true
     fi
   fi
+fi
+
+if [ "${markers_present}" = true ] && [ "${has_valid_block}" = false ]; then
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
 fi
 
 if [ "${has_valid_block}" = true ]; then

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -24,8 +24,8 @@ end_marker="# <<< chezmoi managed keys <<<"
 mkdir -p "${ssh_dir}"
 chmod 700 "${ssh_dir}"
 
-managed_keys="$(mktemp)"
-new_file="$(mktemp)"
+managed_keys="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
+new_file="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
 trap 'rm -f "${managed_keys}" "${new_file}"' EXIT
 
 {{ range $key, $sshKey := $sshKeys -}}

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -11,10 +11,6 @@ set -euo pipefail
 exec </dev/null
 
 {{ $sshKeys := dig "secret" "ssh" "keys" dict . -}}
-{{ if not $sshKeys -}}
-echo "No SSH keys configured; skipping authorized_keys generation."
-exit 0
-{{ end -}}
 
 ssh_dir="${HOME}/.ssh"
 authorized="${ssh_dir}/authorized_keys"

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -3,7 +3,8 @@
 # from deployed public key files. Re-runs when SSH key config changes.
 # Only the managed block below is owned by this script; every line
 # outside it (e.g. keys added via ssh-copy-id or a cloud provider) is
-# preserved byte-for-byte across regeneration.
+# preserved across regeneration (a missing trailing newline may be
+# added when a fresh block is first appended).
 set -euo pipefail
 
 # See run_after_99-secret-status-summary.sh.tmpl for rationale.
@@ -42,9 +43,22 @@ if [ ! -s "${managed_keys}" ]; then
   echo "  WARNING: no public keys were found; managed block will be empty."
 fi
 
-if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
+has_valid_block=false
+if [ -f "${authorized}" ]; then
+  begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
+  end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
+  if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
+    begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
+    end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
+    if [ "${begin_line}" -lt "${end_line}" ]; then
+      has_valid_block=true
+    fi
+  fi
+fi
+
+if [ "${has_valid_block}" = true ]; then
   # Replace the existing managed block in place, preserving every
-  # line outside it byte-for-byte.
+  # line outside it.
   awk -v begin="${begin_marker}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
     $0 == begin {
       print
@@ -56,11 +70,13 @@ if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
     !in_block { print }
   ' "${authorized}" > "${new_file}"
 else
-  # No managed block yet: preserve any existing (foreign) content and
-  # append a fresh managed block.
+  # No managed block yet, or the existing markers are malformed
+  # (missing/duplicated): preserve any existing content as-is and
+  # append a fresh managed block rather than risk dropping foreign
+  # lines by guessing at a broken block's boundaries.
   if [ -f "${authorized}" ]; then
     cat "${authorized}" > "${new_file}"
-    if [ -s "${new_file}" ]; then
+    if [ -s "${new_file}" ] && [ "$(tail -c1 "${new_file}")" != "" ]; then
       printf '\n' >> "${new_file}"
     fi
   else

--- a/home/run_onchange_after_generate-authorized-keys.sh.tmpl
+++ b/home/run_onchange_after_generate-authorized-keys.sh.tmpl
@@ -82,7 +82,7 @@ if [ -n "${begin_line}" ] && [ -n "${end_line}" ]; then
 fi
 
 if [ "${markers_present}" = true ] && [ "${block_shape_ok}" = false ]; then
-  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. A valid block will be updated in place if one can be found, otherwise a fresh block is appended."
 fi
 
 if [ "${has_valid_block}" = true ]; then

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
-# chezmoi run_onchange_after script: Generate ~/.ssh/authorized_keys
-# from deployed public key files. Re-runs when SSH key config changes.
-# Only the managed block below is owned by this script; every line
-# outside it (e.g. keys added via ssh-copy-id or a cloud provider) is
-# preserved byte-for-byte across regeneration.
+# Pre-rendered test fixture for generate-authorized-keys.sh.tmpl.
+# Contains two hardcoded public key names:
+#   primary.pub   - included when present
+#   secondary.pub - included when present
+#
+# This script is intentionally NOT a chezmoi template. It simulates
+# what chezmoi would render when two SSH keys named "primary" and
+# "secondary" are configured under data.secret.ssh.keys.
 set -euo pipefail
-
-# See run_after_99-secret-status-summary.sh.tmpl for rationale.
-exec </dev/null
-
-{{ $sshKeys := dig "secret" "ssh" "keys" dict . -}}
-{{ if not $sshKeys -}}
-echo "No SSH keys configured; skipping authorized_keys generation."
-exit 0
-{{ end -}}
 
 ssh_dir="${HOME}/.ssh"
 authorized="${ssh_dir}/authorized_keys"
@@ -27,24 +21,22 @@ managed_keys="$(mktemp)"
 new_file="$(mktemp)"
 trap 'rm -f "${managed_keys}" "${new_file}"' EXIT
 
-{{ range $key, $sshKey := $sshKeys -}}
-pubfile="${ssh_dir}/{{ $sshKey.filename }}.pub"
-if [ -f "${pubfile}" ]; then
-  cat "${pubfile}" >> "${managed_keys}"
-  echo "" >> "${managed_keys}"
-  echo "  Added {{ $sshKey.filename }}.pub"
-else
-  echo "  Skipped {{ $sshKey.filename }}.pub (not found)"
-fi
-{{ end -}}
+for name in primary secondary; do
+  pubfile="${ssh_dir}/${name}.pub"
+  if [ -f "${pubfile}" ]; then
+    cat "${pubfile}" >> "${managed_keys}"
+    echo "" >> "${managed_keys}"
+    echo "  Added ${name}.pub"
+  else
+    echo "  Skipped ${name}.pub (not found)"
+  fi
+done
 
 if [ ! -s "${managed_keys}" ]; then
   echo "  WARNING: no public keys were found; managed block will be empty."
 fi
 
 if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
-  # Replace the existing managed block in place, preserving every
-  # line outside it byte-for-byte.
   awk -v begin="${begin_marker}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
     $0 == begin {
       print
@@ -56,8 +48,6 @@ if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
     !in_block { print }
   ' "${authorized}" > "${new_file}"
 else
-  # No managed block yet: preserve any existing (foreign) content and
-  # append a fresh managed block.
   if [ -f "${authorized}" ]; then
     cat "${authorized}" > "${new_file}"
     if [ -s "${new_file}" ]; then

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -37,9 +37,13 @@ if [ ! -s "${managed_keys}" ]; then
 fi
 
 has_valid_block=false
+markers_present=false
 if [ -f "${authorized}" ]; then
   begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
   end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
+  if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
+    markers_present=true
+  fi
   if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
     begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
     end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
@@ -47,6 +51,10 @@ if [ -f "${authorized}" ]; then
       has_valid_block=true
     fi
   fi
+fi
+
+if [ "${markers_present}" = true ] && [ "${has_valid_block}" = false ]; then
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
 fi
 
 if [ "${has_valid_block}" = true ]; then

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -17,8 +17,8 @@ end_marker="# <<< chezmoi managed keys <<<"
 mkdir -p "${ssh_dir}"
 chmod 700 "${ssh_dir}"
 
-managed_keys="$(mktemp)"
-new_file="$(mktemp)"
+managed_keys="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
+new_file="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
 trap 'rm -f "${managed_keys}" "${new_file}"' EXIT
 
 for name in primary secondary; do

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -67,7 +67,7 @@ if [ -n "${begin_line}" ] && [ -n "${end_line}" ]; then
 fi
 
 if [ "${markers_present}" = true ] && [ "${block_shape_ok}" = false ]; then
-  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. A valid block will be updated in place if one can be found, otherwise a fresh block is appended."
 fi
 
 if [ "${has_valid_block}" = true ]; then

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -36,41 +36,66 @@ if [ ! -s "${managed_keys}" ]; then
   echo "  WARNING: no public keys were found; managed block will be empty."
 fi
 
-has_valid_block=false
-markers_present=false
+begin_count=0
+end_count=0
 if [ -f "${authorized}" ]; then
-  begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
-  end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
-  if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
-    markers_present=true
-  fi
-  if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
-    begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
-    end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
-    if [ "${begin_line}" -lt "${end_line}" ]; then
-      has_valid_block=true
-    fi
-  fi
+  begin_count=$(grep -cFx "${begin_marker}" "${authorized}" || true)
+  end_count=$(grep -cFx "${end_marker}" "${authorized}" || true)
 fi
 
-if [ "${markers_present}" = true ] && [ "${has_valid_block}" = false ]; then
-  echo "  WARNING: malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+markers_present=false
+if [ "${begin_count}" -gt 0 ] || [ "${end_count}" -gt 0 ]; then
+  markers_present=true
+fi
+
+block_shape_ok=false
+if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
+  block_shape_ok=true
+fi
+
+begin_line=""
+end_line=""
+if [ -f "${authorized}" ]; then
+  begin_line=$(grep -nFx "${begin_marker}" "${authorized}" | tail -1 | cut -d: -f1 || true)
+  if [ -n "${begin_line}" ]; then
+    end_line=$(awk -v b="${begin_line}" -v end="${end_marker}" 'NR > b && $0 == end { print NR; exit }' "${authorized}")
+  fi
+fi
+has_valid_block=false
+if [ -n "${begin_line}" ] && [ -n "${end_line}" ]; then
+  has_valid_block=true
+fi
+
+if [ "${markers_present}" = true ] && [ "${block_shape_ok}" = false ]; then
+  echo "  WARNING: malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
 fi
 
 if [ "${has_valid_block}" = true ]; then
-  awk -v begin="${begin_marker}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
-    $0 == begin {
+  awk -v begin_line="${begin_line}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
+    NR == begin_line {
       print
       while ((getline line < keysfile) > 0) print line
       in_block = 1
       next
     }
-    $0 == end { in_block = 0 }
-    !in_block { print }
+    in_block && $0 == end {
+      print
+      in_block = 0
+      next
+    }
+    in_block { next }
+    { print }
   ' "${authorized}" > "${new_file}"
 else
   if [ -f "${authorized}" ]; then
-    cat "${authorized}" > "${new_file}"
+    if [ -s "${managed_keys}" ]; then
+      non_empty_managed_keys="$(mktemp "${ssh_dir}/.authorized_keys.tmp.XXXXXX")"
+      trap 'rm -f "${managed_keys}" "${new_file}" "${non_empty_managed_keys}"' EXIT
+      grep -v '^$' "${managed_keys}" > "${non_empty_managed_keys}" || true
+      grep -vFxf "${non_empty_managed_keys}" "${authorized}" > "${new_file}" || true
+    else
+      cat "${authorized}" > "${new_file}"
+    fi
     if [ -s "${new_file}" ] && [ "$(tail -c1 "${new_file}")" != "" ]; then
       printf '\n' >> "${new_file}"
     fi

--- a/tests/bash/fixtures/generate-authorized-keys.sh
+++ b/tests/bash/fixtures/generate-authorized-keys.sh
@@ -36,7 +36,20 @@ if [ ! -s "${managed_keys}" ]; then
   echo "  WARNING: no public keys were found; managed block will be empty."
 fi
 
-if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
+has_valid_block=false
+if [ -f "${authorized}" ]; then
+  begin_count=$(grep -cF "${begin_marker}" "${authorized}" || true)
+  end_count=$(grep -cF "${end_marker}" "${authorized}" || true)
+  if [ "${begin_count}" -eq 1 ] && [ "${end_count}" -eq 1 ]; then
+    begin_line=$(grep -nF "${begin_marker}" "${authorized}" | cut -d: -f1)
+    end_line=$(grep -nF "${end_marker}" "${authorized}" | cut -d: -f1)
+    if [ "${begin_line}" -lt "${end_line}" ]; then
+      has_valid_block=true
+    fi
+  fi
+fi
+
+if [ "${has_valid_block}" = true ]; then
   awk -v begin="${begin_marker}" -v end="${end_marker}" -v keysfile="${managed_keys}" '
     $0 == begin {
       print
@@ -50,7 +63,7 @@ if [ -f "${authorized}" ] && grep -qF "${begin_marker}" "${authorized}"; then
 else
   if [ -f "${authorized}" ]; then
     cat "${authorized}" > "${new_file}"
-    if [ -s "${new_file}" ]; then
+    if [ -s "${new_file}" ] && [ "$(tail -c1 "${new_file}")" != "" ]; then
       printf '\n' >> "${new_file}"
     fi
   else

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -135,6 +135,10 @@ setup() {
 
   assert_file_exists "$AUTHORIZED"
   assert_output --partial 'WARNING: no public keys were found'
+
+  run cat "$AUTHORIZED"
+  assert_output --partial '# >>> chezmoi managed keys >>>'
+  assert_output --partial '# <<< chezmoi managed keys <<<'
 }
 
 @test "falls back to append instead of dropping content when the end marker is missing" {

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -38,7 +38,7 @@ setup() {
   run bash "$FIXTURE"
   assert_success
 
-  run stat -c '%a' "$AUTHORIZED"
+  run bash -c "stat -c '%a' '$AUTHORIZED' 2>/dev/null || stat -f '%A' '$AUTHORIZED'"
   assert_output '600'
 }
 

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -129,6 +129,7 @@ setup() {
 
   run bash "$FIXTURE"
   assert_success
+  assert_output --partial 'WARNING: malformed managed-key markers found'
 
   run cat "$AUTHORIZED"
   assert_output --partial 'ssh-rsa FOREIGN untouched'
@@ -142,8 +143,17 @@ setup() {
 
   run bash "$FIXTURE"
   assert_success
+  assert_output --partial 'WARNING: malformed managed-key markers found'
 
   run cat "$AUTHORIZED"
   assert_output --partial 'ssh-rsa FOREIGN between-blocks'
   assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}
+
+@test "does not warn about malformed markers on a normal run" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+  refute_output --partial 'WARNING: malformed managed-key markers found'
 }

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -122,3 +122,28 @@ setup() {
   assert_file_exists "$AUTHORIZED"
   assert_output --partial 'WARNING: no public keys were found'
 }
+
+@test "falls back to append instead of dropping content when the end marker is missing" {
+  printf 'ssh-rsa FOREIGN untouched\n# >>> chezmoi managed keys >>>\nssh-rsa STALE stale-key\n' > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN untouched'
+  assert_output --partial 'ssh-rsa STALE stale-key'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}
+
+@test "falls back to append instead of guessing when markers are duplicated" {
+  printf '# >>> chezmoi managed keys >>>\nssh-rsa OLD1 old\n# <<< chezmoi managed keys <<<\nssh-rsa FOREIGN between-blocks\n# >>> chezmoi managed keys >>>\nssh-rsa OLD2 old\n# <<< chezmoi managed keys <<<\n' > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN between-blocks'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -63,6 +63,20 @@ setup() {
   assert_output --partial 'ssh-ed25519 AAAA primary@test'
 }
 
+@test "does not duplicate a legacy key already present in an unmarked file" {
+  printf 'ssh-ed25519 AAAA primary@test\n\nssh-rsa FOREIGN other-machine\n' > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run grep -c 'ssh-ed25519 AAAA primary@test' "$AUTHORIZED"
+  assert_output '1'
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN other-machine'
+}
+
 @test "preserves foreign lines on both sides of an existing managed block" {
   echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
   run bash "$FIXTURE"
@@ -146,6 +160,55 @@ setup() {
   assert_output --partial 'WARNING: malformed managed-key markers found'
 
   run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN between-blocks'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}
+
+@test "converges on the same block count after repeated runs when the end marker was missing" {
+  printf 'ssh-rsa FOREIGN untouched\n# >>> chezmoi managed keys >>>\nssh-rsa STALE stale-key\n' > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+  run grep -c '# >>> chezmoi managed keys >>>' "$AUTHORIZED"
+  assert_output '2'
+
+  run bash "$FIXTURE"
+  assert_success
+  cp "$AUTHORIZED" "$BATS_TEST_TMPDIR/after-run2"
+
+  run bash "$FIXTURE"
+  assert_success
+  run grep -c '# >>> chezmoi managed keys >>>' "$AUTHORIZED"
+  assert_output '2'
+  run diff "$BATS_TEST_TMPDIR/after-run2" "$AUTHORIZED"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN untouched'
+  assert_output --partial 'ssh-rsa STALE stale-key'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}
+
+@test "converges on the same block count after repeated runs when markers were duplicated" {
+  printf '# >>> chezmoi managed keys >>>\nssh-rsa OLD1 old\n# <<< chezmoi managed keys <<<\nssh-rsa FOREIGN between-blocks\n# >>> chezmoi managed keys >>>\nssh-rsa OLD2 old\n# <<< chezmoi managed keys <<<\n' > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+  run bash "$FIXTURE"
+  assert_success
+  cp "$AUTHORIZED" "$BATS_TEST_TMPDIR/after-run2"
+
+  run bash "$FIXTURE"
+  assert_success
+  run grep -c '# >>> chezmoi managed keys >>>' "$AUTHORIZED"
+  assert_output '2'
+  run diff "$BATS_TEST_TMPDIR/after-run2" "$AUTHORIZED"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa OLD1 old'
   assert_output --partial 'ssh-rsa FOREIGN between-blocks'
   assert_output --partial 'ssh-ed25519 AAAA primary@test'
 }

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -151,7 +151,7 @@ setup() {
   assert_output --partial 'ssh-ed25519 AAAA primary@test'
 }
 
-@test "falls back to append instead of guessing when markers are duplicated" {
+@test "updates the most recent valid block in place when markers are duplicated" {
   printf '# >>> chezmoi managed keys >>>\nssh-rsa OLD1 old\n# <<< chezmoi managed keys <<<\nssh-rsa FOREIGN between-blocks\n# >>> chezmoi managed keys >>>\nssh-rsa OLD2 old\n# <<< chezmoi managed keys <<<\n' > "$AUTHORIZED"
   echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
 

--- a/tests/bash/generate-authorized-keys.bats
+++ b/tests/bash/generate-authorized-keys.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# Tests for the Bash authorized_keys generator script.
+# Exercises: managed-block creation, preservation of foreign
+# out-of-band lines, block replacement, and idempotency.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/bats-support/load'
+  load 'helpers/bats-assert/load'
+  load 'helpers/bats-file/load'
+
+  export HOME="$BATS_TEST_TMPDIR"
+  SSH_DIR="$HOME/.ssh"
+  AUTHORIZED="$SSH_DIR/authorized_keys"
+  FIXTURE="$BATS_TEST_DIRNAME/fixtures/generate-authorized-keys.sh"
+
+  mkdir -p "$SSH_DIR"
+}
+
+@test "creates authorized_keys with a managed block on first run" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+  echo "ssh-ed25519 BBBB secondary@test" > "$SSH_DIR/secondary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial '# >>> chezmoi managed keys >>>'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+  assert_output --partial 'ssh-ed25519 BBBB secondary@test'
+  assert_output --partial '# <<< chezmoi managed keys <<<'
+}
+
+@test "sets file permissions to 600" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run stat -c '%a' "$AUTHORIZED"
+  assert_output '600'
+}
+
+@test "skips missing public keys" {
+  echo "ssh-ed25519 BBBB secondary@test" > "$SSH_DIR/secondary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+  assert_output --partial 'Skipped primary.pub (not found)'
+  assert_output --partial 'Added secondary.pub'
+}
+
+@test "preserves a foreign line that predates the managed block" {
+  echo "ssh-rsa FOREIGN from-cloud-provider" > "$AUTHORIZED"
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_output --partial 'ssh-rsa FOREIGN from-cloud-provider'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+}
+
+@test "preserves foreign lines on both sides of an existing managed block" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+  run bash "$FIXTURE"
+  assert_success
+
+  {
+    echo "ssh-rsa FOREIGN-BEFORE ssh-copy-id"
+    cat "$AUTHORIZED"
+    echo "ssh-rsa FOREIGN-AFTER manually-added"
+  } > "$BATS_TEST_TMPDIR/new-authorized"
+  mv "$BATS_TEST_TMPDIR/new-authorized" "$AUTHORIZED"
+
+  echo "ssh-ed25519 BBBB secondary@test" > "$SSH_DIR/secondary.pub"
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  assert_line --index 0 'ssh-rsa FOREIGN-BEFORE ssh-copy-id'
+  assert_output --partial 'ssh-ed25519 AAAA primary@test'
+  assert_output --partial 'ssh-ed25519 BBBB secondary@test'
+  assert_line --index $((${#lines[@]} - 1)) 'ssh-rsa FOREIGN-AFTER manually-added'
+}
+
+@test "removes a key from the managed block when it disappears from config" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+  echo "ssh-ed25519 BBBB secondary@test" > "$SSH_DIR/secondary.pub"
+  run bash "$FIXTURE"
+  assert_success
+
+  rm "$SSH_DIR/primary.pub"
+  run bash "$FIXTURE"
+  assert_success
+
+  run cat "$AUTHORIZED"
+  refute_output --partial 'ssh-ed25519 AAAA primary@test'
+  assert_output --partial 'ssh-ed25519 BBBB secondary@test'
+}
+
+@test "re-running with unchanged keys produces no diff" {
+  echo "ssh-ed25519 AAAA primary@test" > "$SSH_DIR/primary.pub"
+  echo "ssh-ed25519 BBBB secondary@test" > "$SSH_DIR/secondary.pub"
+  run bash "$FIXTURE"
+  assert_success
+  cp "$AUTHORIZED" "$BATS_TEST_TMPDIR/before"
+
+  run bash "$FIXTURE"
+  assert_success
+
+  run diff "$BATS_TEST_TMPDIR/before" "$AUTHORIZED"
+  assert_success
+}
+
+@test "creates an authorized_keys file with an empty managed block when no keys exist" {
+  run bash "$FIXTURE"
+  assert_success
+
+  assert_file_exists "$AUTHORIZED"
+  assert_output --partial 'WARNING: no public keys were found'
+}

--- a/tests/powershell/fixtures/generate-authorized-keys.ps1
+++ b/tests/powershell/fixtures/generate-authorized-keys.ps1
@@ -40,13 +40,18 @@ if (Test-Path $authorized) {
 
 $beginCount = ($existingLines | Where-Object { $_ -eq $beginMarker }).Count
 $endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
-$beginIndex = [array]::IndexOf($existingLines, $beginMarker)
-$endIndex = [array]::IndexOf($existingLines, $endMarker)
-$hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 $markersPresent = ($beginCount -gt 0) -or ($endCount -gt 0)
+$blockShapeOk = ($beginCount -eq 1) -and ($endCount -eq 1)
 
-if ($markersPresent -and -not $hasValidBlock) {
-  Write-Warning "Malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+$beginIndex = [array]::LastIndexOf($existingLines, $beginMarker)
+$endIndex = -1
+if ($beginIndex -ge 0) {
+  $endIndex = [array]::IndexOf($existingLines, $endMarker, $beginIndex + 1)
+}
+$hasValidBlock = ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
+
+if ($markersPresent -and -not $blockShapeOk) {
+  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
 }
 
 $outLines = @()
@@ -61,7 +66,7 @@ if ($hasValidBlock) {
     $outLines += $existingLines[($endIndex + 1)..($existingLines.Count - 1)]
   }
 } else {
-  $outLines += $existingLines
+  $outLines += $existingLines | Where-Object { $managedLines -notcontains $_ }
   $outLines += $beginMarker
   $outLines += $managedLines
   $outLines += $endMarker

--- a/tests/powershell/fixtures/generate-authorized-keys.ps1
+++ b/tests/powershell/fixtures/generate-authorized-keys.ps1
@@ -13,22 +13,53 @@ $homeDir = if ($env:AUTHORIZED_KEYS_HOME) {
 
 $sshDir = Join-Path $homeDir '.ssh'
 $authorized = Join-Path $sshDir 'authorized_keys'
+$beginMarker = '# >>> chezmoi managed keys >>>'
+$endMarker = '# <<< chezmoi managed keys <<<'
 
 New-Item -ItemType Directory -Path $sshDir -Force | Out-Null
 
-$lines = @()
+$managedLines = @()
 foreach ($name in @('primary.pub', 'secondary.pub')) {
   $pubFile = Join-Path $sshDir $name
   if (Test-Path $pubFile) {
-    $lines += (Get-Content -Path $pubFile -Raw).TrimEnd()
+    $managedLines += (Get-Content -Path $pubFile -Raw).TrimEnd()
+    Write-Host "  Added $name"
+  } else {
+    Write-Host "  Skipped $name (not found)"
   }
 }
 
-if ($lines.Count -eq 0) {
-  Write-Warning 'No public keys were found; authorized_keys will be empty.'
+if ($managedLines.Count -eq 0) {
+  Write-Warning 'No public keys were found; managed block will be empty.'
 }
 
-$lines -join "`n" | Set-Content -Path $authorized -Encoding utf8NoBOM -NoNewline
+$existingLines = @()
+if (Test-Path $authorized) {
+  $existingLines = @(Get-Content -Path $authorized)
+}
+
+$beginIndex = [array]::IndexOf($existingLines, $beginMarker)
+$endIndex = [array]::IndexOf($existingLines, $endMarker)
+
+$outLines = @()
+if ($beginIndex -ge 0 -and $endIndex -gt $beginIndex) {
+  if ($beginIndex -gt 0) {
+    $outLines += $existingLines[0..($beginIndex - 1)]
+  }
+  $outLines += $beginMarker
+  $outLines += $managedLines
+  $outLines += $endMarker
+  if ($endIndex + 1 -lt $existingLines.Count) {
+    $outLines += $existingLines[($endIndex + 1)..($existingLines.Count - 1)]
+  }
+} else {
+  $outLines += $existingLines
+  $outLines += $beginMarker
+  $outLines += $managedLines
+  $outLines += $endMarker
+}
+
+($outLines -join "`n") + "`n" | Set-Content -Path $authorized -Encoding utf8NoBOM -NoNewline
 
 icacls $authorized /inheritance:r `
   /grant:r "${env:USERNAME}:(F)" `

--- a/tests/powershell/fixtures/generate-authorized-keys.ps1
+++ b/tests/powershell/fixtures/generate-authorized-keys.ps1
@@ -51,7 +51,7 @@ if ($beginIndex -ge 0) {
 $hasValidBlock = ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 
 if ($markersPresent -and -not $blockShapeOk) {
-  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. Regeneration will keep updating the most recent block in place."
+  Write-Warning "Malformed managed-key markers found in ${authorized}; remove the stale/duplicate markers manually. A valid block will be updated in place if one can be found, otherwise a fresh block is appended."
 }
 
 $outLines = @()

--- a/tests/powershell/fixtures/generate-authorized-keys.ps1
+++ b/tests/powershell/fixtures/generate-authorized-keys.ps1
@@ -38,11 +38,14 @@ if (Test-Path $authorized) {
   $existingLines = @(Get-Content -Path $authorized)
 }
 
+$beginCount = ($existingLines | Where-Object { $_ -eq $beginMarker }).Count
+$endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
 $beginIndex = [array]::IndexOf($existingLines, $beginMarker)
 $endIndex = [array]::IndexOf($existingLines, $endMarker)
+$hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
 
 $outLines = @()
-if ($beginIndex -ge 0 -and $endIndex -gt $beginIndex) {
+if ($hasValidBlock) {
   if ($beginIndex -gt 0) {
     $outLines += $existingLines[0..($beginIndex - 1)]
   }

--- a/tests/powershell/fixtures/generate-authorized-keys.ps1
+++ b/tests/powershell/fixtures/generate-authorized-keys.ps1
@@ -43,6 +43,11 @@ $endCount = ($existingLines | Where-Object { $_ -eq $endMarker }).Count
 $beginIndex = [array]::IndexOf($existingLines, $beginMarker)
 $endIndex = [array]::IndexOf($existingLines, $endMarker)
 $hasValidBlock = ($beginCount -eq 1) -and ($endCount -eq 1) -and ($beginIndex -ge 0) -and ($endIndex -gt $beginIndex)
+$markersPresent = ($beginCount -gt 0) -or ($endCount -gt 0)
+
+if ($markersPresent -and -not $hasValidBlock) {
+  Write-Warning "Malformed managed-key markers found in ${authorized}; appending a fresh block instead of editing in place. Remove the stale/duplicate markers manually to stop new blocks from accumulating."
+}
 
 $outLines = @()
 if ($hasValidBlock) {

--- a/tests/powershell/generate-authorized-keys.Tests.ps1
+++ b/tests/powershell/generate-authorized-keys.Tests.ps1
@@ -163,7 +163,7 @@ Describe 'generate-authorized-keys' {
     ($warnings.Message -join "`n") | Should -Match 'Malformed managed-key markers'
   }
 
-  It 'falls back to append instead of guessing when markers are duplicated' {
+  It 'updates the most recent valid block in place when markers are duplicated' {
     @(
       $script:BeginMarker, 'ssh-rsa OLD1 old', $script:EndMarker,
       'ssh-rsa FOREIGN between-blocks',

--- a/tests/powershell/generate-authorized-keys.Tests.ps1
+++ b/tests/powershell/generate-authorized-keys.Tests.ps1
@@ -141,12 +141,13 @@ Describe 'generate-authorized-keys' {
     'ssh-ed25519 AAAA primary@test' |
       Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
 
-    & $script:Fixture
+    $warnings = & $script:Fixture 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
 
     $content = Get-Content $script:Authorized
     $content | Should -Contain 'ssh-rsa FOREIGN untouched'
     $content | Should -Contain 'ssh-rsa STALE stale-key'
     $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+    ($warnings.Message -join "`n") | Should -Match 'Malformed managed-key markers'
   }
 
   It 'falls back to append instead of guessing when markers are duplicated' {
@@ -158,10 +159,20 @@ Describe 'generate-authorized-keys' {
     'ssh-ed25519 AAAA primary@test' |
       Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
 
-    & $script:Fixture
+    $warnings = & $script:Fixture 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
 
     $content = Get-Content $script:Authorized
     $content | Should -Contain 'ssh-rsa FOREIGN between-blocks'
     $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+    ($warnings.Message -join "`n") | Should -Match 'Malformed managed-key markers'
+  }
+
+  It 'does not warn about malformed markers on a normal run' {
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    $warnings = & $script:Fixture 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+    ($warnings.Message -join "`n") | Should -Not -Match 'Malformed managed-key markers'
   }
 }

--- a/tests/powershell/generate-authorized-keys.Tests.ps1
+++ b/tests/powershell/generate-authorized-keys.Tests.ps1
@@ -88,6 +88,19 @@ Describe 'generate-authorized-keys' {
     $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
   }
 
+  It 'does not duplicate a legacy key already present in an unmarked file' {
+    @('ssh-ed25519 AAAA primary@test', 'ssh-rsa FOREIGN other-machine') |
+      Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    & $script:Fixture
+
+    $content = Get-Content $script:Authorized
+    ($content | Where-Object { $_ -eq 'ssh-ed25519 AAAA primary@test' }).Count | Should -Be 1
+    $content | Should -Contain 'ssh-rsa FOREIGN other-machine'
+  }
+
   It 'preserves foreign lines on both sides of an existing managed block' {
     'ssh-ed25519 AAAA primary@test' |
       Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
@@ -174,5 +187,57 @@ Describe 'generate-authorized-keys' {
     $warnings = & $script:Fixture 3>&1 | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
 
     ($warnings.Message -join "`n") | Should -Not -Match 'Malformed managed-key markers'
+  }
+
+  It 'converges on the same block count after repeated runs when the end marker was missing' {
+    @('ssh-rsa FOREIGN untouched', $script:BeginMarker, 'ssh-rsa STALE stale-key') |
+      Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    & $script:Fixture | Out-Null
+    $countAfterRun1 = (Get-Content $script:Authorized | Where-Object { $_ -eq $script:BeginMarker }).Count
+    $countAfterRun1 | Should -Be 2
+
+    & $script:Fixture | Out-Null
+    $afterRun2 = Get-Content $script:Authorized -Raw
+
+    & $script:Fixture | Out-Null
+    $afterRun3 = Get-Content $script:Authorized -Raw
+    $countAfterRun3 = (Get-Content $script:Authorized | Where-Object { $_ -eq $script:BeginMarker }).Count
+
+    $countAfterRun3 | Should -Be 2
+    $afterRun3 | Should -Be $afterRun2
+
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-rsa FOREIGN untouched'
+    $content | Should -Contain 'ssh-rsa STALE stale-key'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+  }
+
+  It 'converges on the same block count after repeated runs when markers were duplicated' {
+    @(
+      $script:BeginMarker, 'ssh-rsa OLD1 old', $script:EndMarker,
+      'ssh-rsa FOREIGN between-blocks',
+      $script:BeginMarker, 'ssh-rsa OLD2 old', $script:EndMarker
+    ) | Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    & $script:Fixture | Out-Null
+    & $script:Fixture | Out-Null
+    $afterRun2 = Get-Content $script:Authorized -Raw
+
+    & $script:Fixture | Out-Null
+    $afterRun3 = Get-Content $script:Authorized -Raw
+    $countAfterRun3 = (Get-Content $script:Authorized | Where-Object { $_ -eq $script:BeginMarker }).Count
+
+    $countAfterRun3 | Should -Be 2
+    $afterRun3 | Should -Be $afterRun2
+
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-rsa OLD1 old'
+    $content | Should -Contain 'ssh-rsa FOREIGN between-blocks'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
   }
 }

--- a/tests/powershell/generate-authorized-keys.Tests.ps1
+++ b/tests/powershell/generate-authorized-keys.Tests.ps1
@@ -1,9 +1,12 @@
 # Tests for the PowerShell authorized_keys generator script.
-# Exercises: file content generation, missing key handling, and the
+# Exercises: managed-block content generation, preservation of
+# foreign out-of-band lines, block replacement, idempotency, and the
 # Windows ACL required for LocalSystem sshd reads.
 
 BeforeAll {
   $script:Fixture = Join-Path $PSScriptRoot 'fixtures/generate-authorized-keys.ps1'
+  $script:BeginMarker = '# >>> chezmoi managed keys >>>'
+  $script:EndMarker = '# <<< chezmoi managed keys <<<'
 }
 
 Describe 'generate-authorized-keys' {
@@ -24,6 +27,9 @@ Describe 'generate-authorized-keys' {
     function global:icacls {
       $global:DotfilesTestIcaclsArgs = @($args)
     }
+
+    $script:SshDir = New-Item -ItemType Directory -Path (Join-Path $script:HomeDir '.ssh') -Force
+    $script:Authorized = Join-Path $script:SshDir.FullName 'authorized_keys'
   }
 
   AfterEach {
@@ -33,39 +39,99 @@ Describe 'generate-authorized-keys' {
     Remove-Item Function:\icacls -ErrorAction SilentlyContinue
   }
 
-  It 'creates authorized_keys from the available public keys' {
-    $sshDir = New-Item -ItemType Directory -Path (Join-Path $script:HomeDir '.ssh') -Force
+  It 'creates a managed block from the available public keys' {
     'ssh-ed25519 AAAA primary@test' |
-      Set-Content -Path (Join-Path $sshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
     'ssh-ed25519 BBBB secondary@test' |
-      Set-Content -Path (Join-Path $sshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
 
     & $script:Fixture
 
-    Get-Content (Join-Path $sshDir.FullName 'authorized_keys') -Raw |
-      Should -Be "ssh-ed25519 AAAA primary@test`nssh-ed25519 BBBB secondary@test"
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain $script:BeginMarker
+    $content | Should -Contain $script:EndMarker
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+    $content | Should -Contain 'ssh-ed25519 BBBB secondary@test'
     $global:DotfilesTestIcaclsArgs | Should -Contain '*S-1-5-18:(R)'
     $global:DotfilesTestIcaclsArgs | Should -Contain 'sample-user:(F)'
   }
 
   It 'skips missing public keys and keeps the remaining file content' {
-    $sshDir = New-Item -ItemType Directory -Path (Join-Path $script:HomeDir '.ssh') -Force
     'ssh-ed25519 BBBB secondary@test' |
-      Set-Content -Path (Join-Path $sshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
 
     & $script:Fixture
 
-    Get-Content (Join-Path $sshDir.FullName 'authorized_keys') -Raw |
-      Should -Be 'ssh-ed25519 BBBB secondary@test'
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-ed25519 BBBB secondary@test'
+    $content | Should -Not -Contain 'ssh-ed25519 AAAA primary@test'
   }
 
-  It 'creates an empty authorized_keys file when no public keys exist' {
-    New-Item -ItemType Directory -Path (Join-Path $script:HomeDir '.ssh') -Force | Out-Null
+  It 'creates an authorized_keys file with an empty managed block when no public keys exist' {
+    & $script:Fixture
+
+    $script:Authorized | Should -Exist
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain $script:BeginMarker
+    $content | Should -Contain $script:EndMarker
+  }
+
+  It 'preserves a foreign line that predates the managed block' {
+    'ssh-rsa FOREIGN from-cloud-provider' | Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
 
     & $script:Fixture
 
-    (Join-Path $script:HomeDir '.ssh\authorized_keys') | Should -Exist
-    Get-Content (Join-Path $script:HomeDir '.ssh\authorized_keys') -Raw |
-      Should -BeNullOrEmpty
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-rsa FOREIGN from-cloud-provider'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+  }
+
+  It 'preserves foreign lines on both sides of an existing managed block' {
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+    & $script:Fixture
+
+    $existing = Get-Content $script:Authorized
+    @('ssh-rsa FOREIGN-BEFORE ssh-copy-id') + $existing + @('ssh-rsa FOREIGN-AFTER manually-added') |
+      Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+
+    'ssh-ed25519 BBBB secondary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
+    & $script:Fixture
+
+    $content = Get-Content $script:Authorized
+    $content[0] | Should -Be 'ssh-rsa FOREIGN-BEFORE ssh-copy-id'
+    $content[-1] | Should -Be 'ssh-rsa FOREIGN-AFTER manually-added'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+    $content | Should -Contain 'ssh-ed25519 BBBB secondary@test'
+  }
+
+  It 'removes a key from the managed block when it disappears from config' {
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+    'ssh-ed25519 BBBB secondary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'secondary.pub') -Encoding utf8NoBOM
+    & $script:Fixture
+
+    Remove-Item (Join-Path $script:SshDir.FullName 'primary.pub')
+    & $script:Fixture
+
+    $content = Get-Content $script:Authorized
+    $content | Should -Not -Contain 'ssh-ed25519 AAAA primary@test'
+    $content | Should -Contain 'ssh-ed25519 BBBB secondary@test'
+  }
+
+  It 'produces no diff when re-run with unchanged keys' {
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+    & $script:Fixture
+    $before = Get-Content $script:Authorized -Raw
+
+    & $script:Fixture
+    $after = Get-Content $script:Authorized -Raw
+
+    $after | Should -Be $before
   }
 }

--- a/tests/powershell/generate-authorized-keys.Tests.ps1
+++ b/tests/powershell/generate-authorized-keys.Tests.ps1
@@ -134,4 +134,34 @@ Describe 'generate-authorized-keys' {
 
     $after | Should -Be $before
   }
+
+  It 'falls back to append instead of dropping content when the end marker is missing' {
+    @('ssh-rsa FOREIGN untouched', $script:BeginMarker, 'ssh-rsa STALE stale-key') |
+      Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    & $script:Fixture
+
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-rsa FOREIGN untouched'
+    $content | Should -Contain 'ssh-rsa STALE stale-key'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+  }
+
+  It 'falls back to append instead of guessing when markers are duplicated' {
+    @(
+      $script:BeginMarker, 'ssh-rsa OLD1 old', $script:EndMarker,
+      'ssh-rsa FOREIGN between-blocks',
+      $script:BeginMarker, 'ssh-rsa OLD2 old', $script:EndMarker
+    ) | Set-Content -Path $script:Authorized -Encoding utf8NoBOM
+    'ssh-ed25519 AAAA primary@test' |
+      Set-Content -Path (Join-Path $script:SshDir.FullName 'primary.pub') -Encoding utf8NoBOM
+
+    & $script:Fixture
+
+    $content = Get-Content $script:Authorized
+    $content | Should -Contain 'ssh-rsa FOREIGN between-blocks'
+    $content | Should -Contain 'ssh-ed25519 AAAA primary@test'
+  }
 }


### PR DESCRIPTION
## Summary

`chezmoi apply` regenerated `~/.ssh/authorized_keys` from scratch on
every SSH key config change, on both the POSIX and PowerShell
variants. Any entry added out of band — `ssh-copy-id` from another
machine, cloud-provider injected keys, a co-admin's key — was
destroyed on the next apply, which is a potential remote-lockout.

- Reworked both platform generators
  (`home/run_onchange_after_generate-authorized-keys.sh.tmpl` and
  `.ps1.tmpl`) to own only a delimited managed block:

  ```text
  # >>> chezmoi managed keys >>>
  ...managed keys...
  # <<< chezmoi managed keys <<<
  ```

  On regeneration: an existing block is replaced in place (everything
  outside it is preserved byte-for-byte); if no block exists yet, a
  fresh one is appended after any existing content. File permissions
  (`600` POSIX / ACL on Windows) and a trailing newline are preserved
  as before.
- Added `tests/bash/generate-authorized-keys.bats` (this script had
  no bats coverage before) plus a pre-rendered fixture: first-run
  creation, missing-key skip, foreign lines before/after an existing
  block, key removal from the block, and idempotency.
- Updated `tests/powershell/generate-authorized-keys.Tests.ps1` and
  its fixture for the same managed-block behavior and coverage.

Closes #153

## Functional evidence

Manually exercised both rendered scripts outside the test harness:
first run creates the block; re-running with a foreign line inserted
both before and after the block preserves both lines exactly and only
replaces the block contents; removing a key from config removes it
from the block on the next run; re-running with unchanged keys
produces a byte-identical file (idempotent).

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 221/221
      passing, including the new suite
- [x] `pwsh -c "Invoke-Pester tests/powershell/"` — new/updated specs
      pass (10/10). 5 unrelated failures reproduce identically on
      `master` (Pester 6.0.0 mock-compatibility issues in `40-fzf`,
      `tailscale-serve`, and PSReadLine-startup specs, untouched by
      this change)
- [x] Manual functional verification (see above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SSH public keys are now stored in a clearly marked managed section of `authorized_keys`.
  - Existing unmanaged SSH entries are preserved when keys are added, updated, or removed.
  - Missing or malformed managed sections are handled safely with warnings and fallback behavior.
  - Empty key configurations retain an identifiable managed section.

- **Bug Fixes**
  - Repeated runs now produce consistent results without unnecessary file changes.

- **Tests**
  - Expanded coverage for key updates, preservation, permissions, idempotency, missing keys, and malformed markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->