### PR TITLE
fix(shell): stop double-sourcing conf.d in login+interactive shells

### DIFF
--- a/home/dot_bashrc
+++ b/home/dot_bashrc
@@ -5,10 +5,17 @@
 # Abort if not running interactively
 [[ $- != *i* ]] && return
 
-# Source shared POSIX conf.d (bash + zsh common)
-for f in "$HOME/.config/shell/conf.d/"*.sh; do
-  [[ -r "$f" ]] && . "$f"
-done
+# Source shared POSIX conf.d (bash + zsh common). Guarded by an
+# unexported sentinel so a login+interactive shell doesn't run this
+# loop again after .profile already did. Unexported is load-bearing:
+# it dies with this process, so a fresh subshell still sources conf.d
+# normally.
+if [[ -z "${_dotfiles_confd_loaded:-}" ]]; then
+  for f in "$HOME/.config/shell/conf.d/"*.sh; do
+    [[ -r "$f" ]] && . "$f"
+  done
+  _dotfiles_confd_loaded=1
+fi
 
 # Source bash-specific conf.d
 for f in "$HOME/.config/bash/conf.d/"*.bash; do

--- a/home/dot_config/zsh/dot_zshrc
+++ b/home/dot_config/zsh/dot_zshrc
@@ -2,10 +2,17 @@
 # ~/.config/zsh/.zshrc — Interactive zsh configuration
 # Sources shared POSIX conf.d, zsh-specific conf.d, then tools.
 
-# Source shared POSIX conf.d (bash + zsh common)
-for f in "$HOME/.config/shell/conf.d/"*.sh(N); do
-  [[ -r "$f" ]] && . "$f"
-done
+# Source shared POSIX conf.d (bash + zsh common). Guarded by an
+# unexported sentinel so a login+interactive shell doesn't run this
+# loop again after .zprofile (which sources .profile) already did.
+# Unexported is load-bearing: it dies with this process, so a fresh
+# subshell still sources conf.d normally.
+if [[ -z "${_dotfiles_confd_loaded:-}" ]]; then
+  for f in "$HOME/.config/shell/conf.d/"*.sh(N); do
+    [[ -r "$f" ]] && . "$f"
+  done
+  _dotfiles_confd_loaded=1
+fi
 
 # Source zsh-specific conf.d
 for f in "${ZDOTDIR:-$HOME/.config/zsh}/conf.d/"*.zsh(N); do

--- a/home/dot_profile
+++ b/home/dot_profile
@@ -3,7 +3,14 @@
 # Sourced by bash (via .bash_profile) and zsh (via .zprofile).
 # Delegates to conf.d for modularity; only login-time setup here.
 
-# Source shared conf.d if available
-for f in "$HOME/.config/shell/conf.d/"*.sh; do
-  [ -r "$f" ] && . "$f"
-done
+# Source shared conf.d if available. Guarded by an unexported sentinel
+# so a login+interactive shell (every macOS terminal, the initial WSL
+# shell) doesn't run this loop again from .bashrc/.zshrc. Unexported
+# is load-bearing: it dies with this process, so a fresh subshell
+# still sources conf.d normally.
+if [ -z "${_dotfiles_confd_loaded:-}" ]; then
+  for f in "$HOME/.config/shell/conf.d/"*.sh; do
+    [ -r "$f" ] && . "$f"
+  done
+  _dotfiles_confd_loaded=1
+fi

--- a/tests/bash/conf-d-double-sourcing.bats
+++ b/tests/bash/conf-d-double-sourcing.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# Tests for the shared conf.d double-sourcing guard.
+#
+# home/dot_profile and home/dot_bashrc (and dot_zshrc) each source
+# every ~/.config/shell/conf.d/*.sh script. In a login+interactive
+# shell (every macOS terminal, the initial WSL shell) both the
+# .profile chain and .bashrc/.zshrc run, so without a guard the shared
+# conf.d loop executes twice. A per-process, unexported sentinel
+# variable prevents the second run without leaking into subshells.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/bats-support/load'
+  load 'helpers/bats-assert/load'
+
+  export HOME="$BATS_TEST_TMPDIR"
+  mkdir -p "$HOME/.config/shell/conf.d"
+
+  COUNTER="$HOME/confd-sourced.count"
+  : > "$COUNTER"
+  echo "echo x >> '$COUNTER'" > "$HOME/.config/shell/conf.d/00-counter.sh"
+
+  REPO_HOME="$BATS_TEST_DIRNAME/../../home"
+  cp "$REPO_HOME/dot_profile" "$HOME/.profile"
+  cp "$REPO_HOME/dot_bash_profile" "$HOME/.bash_profile"
+  cp "$REPO_HOME/dot_bashrc" "$HOME/.bashrc"
+}
+
+@test "sources shared conf.d exactly once during a login+interactive bash startup" {
+  bash -li -c true > /dev/null 2>&1
+
+  run wc -l < "$COUNTER"
+  assert_output '1'
+}
+
+@test "a nested interactive bash shell still sources conf.d (sentinel does not leak)" {
+  run bash -li -c "bash -i -c true" 2>/dev/null
+  assert_success
+
+  run wc -l < "$COUNTER"
+  assert_output '2'
+}
+
+@test "a fresh non-interactive bash invocation still sources conf.d via .profile" {
+  run bash -c ". '$HOME/.profile'; wc -l < '$COUNTER'"
+  assert_success
+  assert_output '1'
+}

--- a/tests/bash/conf-d-double-sourcing.bats
+++ b/tests/bash/conf-d-double-sourcing.bats
@@ -25,10 +25,20 @@ setup() {
   cp "$REPO_HOME/dot_profile" "$HOME/.profile"
   cp "$REPO_HOME/dot_bash_profile" "$HOME/.bash_profile"
   cp "$REPO_HOME/dot_bashrc" "$HOME/.bashrc"
+
+  ZDOTDIR="$HOME/.config/zsh"
+  mkdir -p "$ZDOTDIR"
+  cp "$REPO_HOME/dot_config/zsh/dot_zprofile" "$ZDOTDIR/.zprofile"
+  cp "$REPO_HOME/dot_config/zsh/dot_zshrc" "$ZDOTDIR/.zshrc"
+}
+
+require_zsh() {
+  command -v zsh > /dev/null 2>&1 || skip "zsh not available"
 }
 
 @test "sources shared conf.d exactly once during a login+interactive bash startup" {
-  bash -li -c true > /dev/null 2>&1
+  run bash -li -c true
+  assert_success
 
   run wc -l < "$COUNTER"
   assert_output '1'
@@ -46,4 +56,24 @@ setup() {
   run bash -c ". '$HOME/.profile'; wc -l < '$COUNTER'"
   assert_success
   assert_output '1'
+}
+
+@test "sources shared conf.d exactly once during a login+interactive zsh startup" {
+  require_zsh
+
+  run env ZDOTDIR="$ZDOTDIR" zsh -li -c true
+  assert_success
+
+  run wc -l < "$COUNTER"
+  assert_output '1'
+}
+
+@test "a nested interactive zsh shell still sources conf.d (sentinel does not leak)" {
+  require_zsh
+
+  run env ZDOTDIR="$ZDOTDIR" zsh -li -c "ZDOTDIR='$ZDOTDIR' zsh -i -c true"
+  assert_success
+
+  run wc -l < "$COUNTER"
+  assert_output '2'
 }

--- a/tests/bash/conf-d-double-sourcing.bats
+++ b/tests/bash/conf-d-double-sourcing.bats
@@ -40,7 +40,7 @@ require_zsh() {
   run bash -li -c true
   assert_success
 
-  run wc -l < "$COUNTER"
+  run awk 'END{print NR}' "$COUNTER"
   assert_output '1'
 }
 
@@ -48,12 +48,12 @@ require_zsh() {
   run bash -li -c "bash -i -c true" 2>/dev/null
   assert_success
 
-  run wc -l < "$COUNTER"
+  run awk 'END{print NR}' "$COUNTER"
   assert_output '2'
 }
 
 @test "a fresh non-interactive bash invocation still sources conf.d via .profile" {
-  run bash -c ". '$HOME/.profile'; wc -l < '$COUNTER'"
+  run bash -c ". '$HOME/.profile'; awk 'END{print NR}' '$COUNTER'"
   assert_success
   assert_output '1'
 }
@@ -64,7 +64,7 @@ require_zsh() {
   run env ZDOTDIR="$ZDOTDIR" zsh -li -c true
   assert_success
 
-  run wc -l < "$COUNTER"
+  run awk 'END{print NR}' "$COUNTER"
   assert_output '1'
 }
 
@@ -74,6 +74,6 @@ require_zsh() {
   run env ZDOTDIR="$ZDOTDIR" zsh -li -c "ZDOTDIR='$ZDOTDIR' zsh -i -c true"
   assert_success
 
-  run wc -l < "$COUNTER"
+  run awk 'END{print NR}' "$COUNTER"
   assert_output '2'
 }


### PR DESCRIPTION
## Summary

In a login+interactive shell (every macOS terminal, the initial WSL
shell), both `.profile` and `.bashrc`/`.zshrc` sourced every
`~/.config/shell/conf.d/*.sh` script, so scripts that aren't
idempotent duplicated state: `40-homebrew.sh` evaluates `brew
shellenv` twice (duplicated `PATH`/`MANPATH` entries — brew does not
dedup) and `60-mise.sh` runs `mise activate` twice (duplicate
precmd/chpwd hooks).

- Guarded the shared conf.d loop in `home/dot_profile`,
  `home/dot_bashrc`, and `home/dot_config/zsh/dot_zshrc` with a
  per-process, **unexported** sentinel (`_dotfiles_confd_loaded`).
  Unexported is load-bearing: an exported sentinel would leak into
  child shells and skip sourcing there, losing non-inherited state
  such as mise's prompt hooks; unexported dies with the process, so a
  fresh subshell still sources conf.d normally.
- Only the shared loop is guarded; each shell's own
  `conf.d/*.bash`/`conf.d/*.zsh` loop is untouched.
- PowerShell's `conf.d/*.ps1` loading is out of scope — the issue only
  covers the POSIX chain.

Closes #154

## Functional evidence

Simulated a `bash -li`-style login+interactive startup
(`.bash_profile` → `.profile` → `.bashrc`) against a temp conf.d
containing a counter script:

- Before the fix (verified against unmodified `master`): the counter
  incremented **twice** for a single login+interactive startup, and
  **three** times total when a nested interactive shell was spawned
  from it.
- After the fix: the counter increments **once** for the
  login+interactive startup, and **twice** total with a nested shell
  (once per process, as intended — the sentinel does not leak into
  the child).

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 230/230
      passing, including the new
      `tests/bash/conf-d-double-sourcing.bats` suite
- [x] Manual functional verification (see above), including the
      regression check that the new tests fail against unmodified
      `master`
