### PR TITLE
fix(zellij): launch the systemd user unit through a login shell PATH

### DIFF
--- a/home/dot_config/systemd/user/zellij-web.service.tmpl
+++ b/home/dot_config/systemd/user/zellij-web.service.tmpl
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'
+ExecStart=/bin/sh -lc 'exec "%h/.local/bin/ensure-zellij-web"'
 ExecStop=/bin/sh -lc 'if command -v zellij >/dev/null 2>&1; then zellij web --stop >/dev/null 2>&1 || true; fi'
 
 [Install]

--- a/home/dot_config/systemd/user/zellij-web.service.tmpl
+++ b/home/dot_config/systemd/user/zellij-web.service.tmpl
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=%h/.local/bin/ensure-zellij-web
+ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'
 ExecStop=/bin/sh -lc 'if command -v zellij >/dev/null 2>&1; then zellij web --stop >/dev/null 2>&1 || true; fi'
 
 [Install]

--- a/tests/bash/zellij-web-systemd-unit.bats
+++ b/tests/bash/zellij-web-systemd-unit.bats
@@ -18,7 +18,7 @@ setup() {
 @test "ExecStart launches through a login shell to inherit a non-minimal PATH" {
   run grep -F 'ExecStart=' "$UNIT"
   assert_success
-  assert_output "ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'"
+  assert_output "ExecStart=/bin/sh -lc 'exec \"%h/.local/bin/ensure-zellij-web\"'"
 }
 
 @test "unit stays otherwise well-formed" {

--- a/tests/bash/zellij-web-systemd-unit.bats
+++ b/tests/bash/zellij-web-systemd-unit.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Tests for the Linux systemd user unit template for zellij-web.
+# ExecStart must launch through a login shell so the oneshot inherits
+# a non-minimal PATH (systemd's default user PATH doesn't include
+# mise/cargo/homebrew install locations, which makes `command -v
+# zellij` fail and aborts chezmoi apply via the restart under
+# set -euo pipefail).
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load 'helpers/bats-support/load'
+  load 'helpers/bats-assert/load'
+
+  UNIT="$BATS_TEST_DIRNAME/../../home/dot_config/systemd/user/zellij-web.service.tmpl"
+}
+
+@test "ExecStart launches through a login shell to inherit a non-minimal PATH" {
+  run grep -F 'ExecStart=' "$UNIT"
+  assert_success
+  assert_output "ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'"
+}
+
+@test "unit stays otherwise well-formed" {
+  run cat "$UNIT"
+  assert_success
+  assert_output --partial 'Type=oneshot'
+  assert_output --partial 'RemainAfterExit=yes'
+  assert_output --partial 'WantedBy=default.target'
+}
+
+@test "unit passes systemd-analyze verify" {
+  if ! command -v systemd-analyze > /dev/null 2>&1; then
+    skip "systemd-analyze not available"
+  fi
+
+  # systemd-analyze verify infers the unit type from the filename
+  # extension, so the .tmpl suffix must be dropped first.
+  local unit_copy="$BATS_TEST_TMPDIR/zellij-web.service"
+  cp "$UNIT" "$unit_copy"
+
+  run systemd-analyze verify --user "$unit_copy"
+  assert_success
+}

--- a/tests/powershell/zellij-web-assets.Tests.ps1
+++ b/tests/powershell/zellij-web-assets.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'zellij web assets' {
 
     $lines | Should -Contain 'Type=oneshot'
     $lines | Should -Contain 'RemainAfterExit=yes'
-    $lines | Should -Contain "ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'"
+    $lines | Should -Contain "ExecStart=/bin/sh -lc 'exec ""%h/.local/bin/ensure-zellij-web""'"
     $lines | Should -Not -Contain 'ExecStart=%h/.local/bin/ensure-zellij-web'
     $lines | Should -Contain 'WantedBy=default.target'
   }

--- a/tests/powershell/zellij-web-assets.Tests.ps1
+++ b/tests/powershell/zellij-web-assets.Tests.ps1
@@ -99,7 +99,8 @@ Describe 'zellij web assets' {
 
     $lines | Should -Contain 'Type=oneshot'
     $lines | Should -Contain 'RemainAfterExit=yes'
-    $lines | Should -Contain 'ExecStart=%h/.local/bin/ensure-zellij-web'
+    $lines | Should -Contain "ExecStart=/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'"
+    $lines | Should -Not -Contain 'ExecStart=%h/.local/bin/ensure-zellij-web'
     $lines | Should -Contain 'WantedBy=default.target'
   }
 


### PR DESCRIPTION
## Summary

`home/dot_config/systemd/user/zellij-web.service.tmpl`'s `ExecStart`
ran the `ensure-zellij-web` wrapper directly, so the oneshot inherited
systemd's minimal user PATH. When `zellij` is installed via
mise/cargo/homebrew (not `/usr/bin`), `command -v zellij` inside the
wrapper fails, the unit is marked failed, and — because
`run_onchange_after_80-register-zellij-web.sh.tmpl` runs `systemctl
--user restart` under `set -euo pipefail` — the whole `chezmoi apply`
aborts.

- Changed `ExecStart` to `/bin/sh -lc 'exec %h/.local/bin/ensure-zellij-web'`,
  mirroring the macOS LaunchAgent counterpart's login-shell wrapper so
  the unit inherits a full PATH.
- Updated the existing cross-platform assets Pester test to assert the
  new wrapper form.
- Added `tests/bash/zellij-web-systemd-unit.bats`: asserts the exact
  `ExecStart` line, that the unit otherwise stays well-formed, and —
  when available — that it passes `systemd-analyze verify --user`.

Closes #155

## Functional evidence

`systemd-analyze verify --user` on the rendered unit (with the
`.tmpl` suffix dropped, since verify infers the unit type from the
extension) passes with no warnings.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 235/235
      passing, including the new suite (which fails against the
      pre-fix template, verified via a `git stash` round-trip)
- [x] `pwsh -c "Invoke-Pester tests/powershell/zellij-web-assets.Tests.ps1"`
      — 13/13 passing
- [x] Manual `systemd-analyze verify --user` on the rendered unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux service startup by running the web setup command through a login shell, ensuring required environment paths are available.
  * Preserved service behavior while improving command execution reliability.

* **Tests**
  * Added validation for service configuration directives and systemd unit syntax.
  * Updated platform tests to verify the revised startup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->