### PR TITLE
fix(gpg): skip non-hex user.signingkey values in gpg-cache

### DIFF
--- a/home/dot_local/bin/executable_gpg-cache
+++ b/home/dot_local/bin/executable_gpg-cache
@@ -19,9 +19,11 @@ update_gpg_session() {
 }
 
 get_signing_keys() {
-  # 1. Default git signing key
+  # 1. Default git signing key (hex fingerprints only; when
+  #    gpg.format=ssh, user.signingkey is an SSH public key path,
+  #    which gpg cannot sign with, so skip it silently)
   if command -v git >/dev/null 2>&1; then
-    git config user.signingkey 2>/dev/null || true
+    git config user.signingkey 2>/dev/null | grep -E '^[A-Fa-f0-9]+$' || true
   fi
 
   # 2. Per-directory profile signing keys

--- a/home/dot_local/bin/executable_gpg-cache.ps1
+++ b/home/dot_local/bin/executable_gpg-cache.ps1
@@ -11,12 +11,14 @@ function global:Get-DotfilesGpgCommand {
 function global:Get-DotfilesGpgSigningKeys {
   $keys = [System.Collections.Generic.List[string]]::new()
 
-  # 1. Default git signing key
+  # 1. Default git signing key (hex fingerprints only; when
+  #    gpg.format=ssh, user.signingkey is an SSH public key path,
+  #    which gpg cannot sign with, so skip it silently)
   $gitCmd = Get-Command git -ErrorAction SilentlyContinue
   if ($gitCmd) {
     try {
       $defaultKey = & $gitCmd.Name config user.signingkey 2>$null
-      if ($defaultKey) { $keys.Add($defaultKey) }
+      if ($defaultKey -match '^[A-Fa-f0-9]+$') { $keys.Add($defaultKey) }
     } catch [System.Exception] {
     }
   }

--- a/tests/bash/05-gpg.bats
+++ b/tests/bash/05-gpg.bats
@@ -107,7 +107,7 @@ EOF
   make_mock_command gpg-connect-agent "printf 'agent:%s\n' \"\$*\" >> \"${GPG_HELPER_LOG}\""
   make_mock_command gpg "printf 'gpg:%s\n' \"\$*\" >> \"${GPG_HELPER_LOG}\"; exit 0"
   make_mock_command git \
-    "if [ \"\$1\" = 'config' ] && [ \"\$2\" = 'user.signingkey' ]; then printf 'KEY1\n'; exit 0; fi; exit 1"
+    "if [ \"\$1\" = 'config' ] && [ \"\$2\" = 'user.signingkey' ]; then printf 'EEEE5555FFFF6666\n'; exit 0; fi; exit 1"
 
   mkdir -p "$HOME/.config/git/profiles"
   printf '[user]\n  signingkey = "CCCC3333DDDD4444"\n' > "$HOME/.config/git/profiles/work"
@@ -115,10 +115,26 @@ EOF
   run /bin/sh "$CACHE_PATH"
 
   assert_success
-  assert_output --partial "Prompting GPG passphrase for key KEY1"
+  assert_output --partial "Prompting GPG passphrase for key EEEE5555FFFF6666"
   assert_output --partial "Prompting GPG passphrase for key CCCC3333DDDD4444"
-  assert_file_contains "$GPG_HELPER_LOG" "gpg:--local-user KEY1 --clearsign --yes"
+  assert_file_contains "$GPG_HELPER_LOG" "gpg:--local-user EEEE5555FFFF6666 --clearsign --yes"
   assert_file_contains "$GPG_HELPER_LOG" "gpg:--local-user CCCC3333DDDD4444 --clearsign --yes"
+}
+
+@test "gpg-cache skips a non-hex user.signingkey (SSH key path) and falls back to the default key" {
+  make_mock_command tty "printf '/dev/pts/55\n'"
+  make_mock_command gpg-connect-agent "printf 'agent:%s\n' \"\$*\" >> \"${GPG_HELPER_LOG}\""
+  make_mock_command gpg "printf 'gpg:%s\n' \"\$*\" >> \"${GPG_HELPER_LOG}\"; exit 0"
+  make_mock_command git \
+    "if [ \"\$1\" = 'config' ] && [ \"\$2\" = 'user.signingkey' ]; then printf '%s/.ssh/id_ed25519.pub\n' \"$HOME\"; exit 0; fi; exit 1"
+
+  run /bin/sh "$CACHE_PATH"
+
+  assert_success
+  assert_output --partial "Prompting GPG passphrase"
+  refute_output --partial "--local-user"
+  run grep -- '--local-user' "$GPG_HELPER_LOG"
+  assert_failure
 }
 
 @test "gpg-cache returns failure when gpg exits nonzero" {

--- a/tests/bash/05-gpg.bats
+++ b/tests/bash/05-gpg.bats
@@ -133,6 +133,7 @@ EOF
   assert_success
   assert_output --partial "Prompting GPG passphrase"
   refute_output --partial "--local-user"
+  assert_file_contains "$GPG_HELPER_LOG" "gpg:--clearsign --yes"
   run grep -- '--local-user' "$GPG_HELPER_LOG"
   assert_failure
 }

--- a/tests/powershell/gpg-cache.Tests.ps1
+++ b/tests/powershell/gpg-cache.Tests.ps1
@@ -104,6 +104,22 @@ Describe 'gpg-cache' {
     $keys | Should -Contain 'AAAA1111BBBB2222'
   }
 
+  It 'skips a non-hex user.signingkey (SSH key path)' {
+    function script:git {
+      if ($args[0] -eq 'config' -and $args[1] -eq 'user.signingkey') {
+        "$HOME/.ssh/id_ed25519.pub"
+        $global:LASTEXITCODE = 0
+      }
+    }
+    Mock Get-Command {
+      [pscustomobject]@{ Name = 'git'; CommandType = 'Function' }
+    } -ParameterFilter { $Name -eq 'git' }
+
+    $keys = Get-DotfilesGpgSigningKeys
+
+    $keys.Count | Should -Be 0
+  }
+
   It 'reads signing keys from profile config files' {
     $profileDir = Join-Path (Join-Path (Join-Path $HOME '.config') 'git') 'profiles'
     $null = New-Item -ItemType Directory -Path $profileDir -Force


### PR DESCRIPTION
## Summary

`home/dot_local/bin/executable_gpg-cache` collects signing keys for
cache warm-up. Keys parsed from profile files are filtered to hex
fingerprints, but the value of the global `git config
user.signingkey` was appended unfiltered. When the machine is
configured for SSH signing (`gpg.format = ssh`), `user.signingkey` is
an `~/.ssh/*.pub` path; the loop then runs `gpg --local-user
"<path>" --clearsign`, which fails and makes the tool exit 1 even
though there is nothing for GPG to cache.

- Applied the same hex-fingerprint filter already used for
  profile-config keys to the git config value, in both the POSIX
  (`executable_gpg-cache`) and PowerShell
  (`executable_gpg-cache.ps1`) variants — the PowerShell tool had the
  identical underlying bug, though the issue only called out the
  POSIX one; fixed both for consistency since they're the same tool
  cross-platform.
- Extended the existing `tests/bash/05-gpg.bats` coverage (the
  issue's "no bats test covers this script" note predates that file)
  with the SSH-path-skip scenario, and fixed a test-data bug it
  surfaced along the way: the "multiple keys" test used a non-hex
  dummy value (`KEY1`) as a stand-in signing key, which this fix now
  correctly filters — replaced it with a realistic hex fingerprint.
- Added the equivalent case to
  `tests/powershell/gpg-cache.Tests.ps1`.

Closes #157

## Functional evidence

Verified via `git stash` round-trips that all new/changed assertions
fail against the pre-fix scripts (the SSH path was passed to `gpg
--local-user` and the multi-key test's dummy value would have been
silently dropped by the fix) and pass after it.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 242/242
      passing
- [x] `pwsh -c "Invoke-Pester tests/powershell/gpg-cache.Tests.ps1"`
      — 14/14 passing
- [x] Manual regression verification (see above)
