### PR TITLE
fix(editors): curl.exe on ps5.1 + pinned vim-plug bootstrap

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -37,22 +37,29 @@ words:
   - exrc
   - gdefault
   - gpgconf
+  - hlsearch
   - HKLM
   - inputrc
   - inshellisense
+  - junegunn
   - keepassxc
   - kito
   - luac
   - luks
+  - MYVIMRC
+  - nnoremap
   - psmux
   - pylint
   - rerere
+  - sheerun
   - taskrc
+  - tpope
   - unpushed
   - unreplied
   - waivable
   - wgetrc
   - viml
+  - vimrc
   - virtiofs
   - WORKFPR
   - xclip

--- a/home/dot_vimrc
+++ b/home/dot_vimrc
@@ -7,7 +7,7 @@
 let data_dir = has('nvim') ? stdpath('data') . '/site' : '~/.vim'
 if empty(glob(data_dir . '/autoload/plug.vim'))
   silent execute '!curl -fLo '.data_dir.'/autoload/plug.vim --create-dirs'
-    \ .' https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+    \ .' https://raw.githubusercontent.com/junegunn/vim-plug/88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim'
   autocmd VimEnter * PlugInstall --sync | source $MYVIMRC
 endif
 

--- a/home/run_onchange_after_55-setup-editors.ps1.tmpl
+++ b/home/run_onchange_after_55-setup-editors.ps1.tmpl
@@ -51,7 +51,10 @@ if ($vimCmd) {
     } else {
       Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
       try {
-        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing
+        # PS5.1's .NET default protocol set can exclude TLS 1.2, which
+        # GitHub's raw content endpoint requires.
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing -ErrorAction Stop
       } catch {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }

--- a/home/run_onchange_after_55-setup-editors.ps1.tmpl
+++ b/home/run_onchange_after_55-setup-editors.ps1.tmpl
@@ -51,13 +51,18 @@ if ($vimCmd) {
       }
     } else {
       Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
+      # PS5.1's .NET default protocol set can exclude TLS 1.2, which
+      # GitHub's raw content endpoint requires. Add it without
+      # dropping whatever protocols were already enabled, and scope
+      # the change to this call only.
+      $prevProtocol = [Net.ServicePointManager]::SecurityProtocol
       try {
-        # PS5.1's .NET default protocol set can exclude TLS 1.2, which
-        # GitHub's raw content endpoint requires.
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        [Net.ServicePointManager]::SecurityProtocol = $prevProtocol -bor [Net.SecurityProtocolType]::Tls12
         Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing -ErrorAction Stop
       } catch {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
+      } finally {
+        [Net.ServicePointManager]::SecurityProtocol = $prevProtocol
       }
     }
   }

--- a/home/run_onchange_after_55-setup-editors.ps1.tmpl
+++ b/home/run_onchange_after_55-setup-editors.ps1.tmpl
@@ -30,20 +30,31 @@ if ($vimCmd) {
   }
 
   if (-not (Test-Path $plugVim)) {
-    $curlCmd = Get-Command curl -ErrorAction SilentlyContinue
-    if ($curlCmd) {
+    # On Windows PowerShell 5.1, "curl" is a built-in alias for
+    # Invoke-WebRequest, so Get-Command curl matches the alias
+    # instead of the real binary and parameter binding fails.
+    # Resolve curl.exe explicitly (extension bypasses alias
+    # resolution) and fall back to Invoke-WebRequest when absent.
+    $plugUrl = 'https://raw.githubusercontent.com/junegunn/vim-plug/88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim'
+    $plugDir = Split-Path $plugVim -Parent
+    if (-not (Test-Path $plugDir)) {
+      New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
+    }
+
+    $curlExeCmd = Get-Command curl.exe -ErrorAction SilentlyContinue
+    if ($curlExeCmd) {
       Write-Host '  Bootstrapping vim-plug...'
-      $plugDir = Split-Path $plugVim -Parent
-      if (-not (Test-Path $plugDir)) {
-        New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
-      }
-      & curl -fLo $plugVim --create-dirs `
-        'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim' 2>&1
+      & curl.exe -fLo $plugVim --create-dirs $plugUrl 2>&1
       if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }
     } else {
-      Write-Host '  WARNING: curl not found; cannot bootstrap vim-plug. Skipping vim.'
+      Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
+      try {
+        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing
+      } catch {
+        Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
+      }
     }
   }
 

--- a/home/run_onchange_after_55-setup-editors.ps1.tmpl
+++ b/home/run_onchange_after_55-setup-editors.ps1.tmpl
@@ -41,10 +41,11 @@ if ($vimCmd) {
       New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
     }
 
-    $curlExeCmd = Get-Command curl.exe -ErrorAction SilentlyContinue
+    $curlExeCmd = Get-Command curl.exe -CommandType Application -ErrorAction SilentlyContinue
     if ($curlExeCmd) {
       Write-Host '  Bootstrapping vim-plug...'
-      & curl.exe -fLo $plugVim --create-dirs $plugUrl 2>&1
+      $curlExePath = if ($curlExeCmd.Path) { $curlExeCmd.Path } else { $curlExeCmd.Source }
+      & $curlExePath -fLo $plugVim --create-dirs $plugUrl 2>&1
       if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }

--- a/home/run_onchange_after_55-setup-editors.sh.tmpl
+++ b/home/run_onchange_after_55-setup-editors.sh.tmpl
@@ -29,7 +29,7 @@ if command -v vim &>/dev/null; then
     if command -v curl &>/dev/null; then
       echo "  Bootstrapping vim-plug..."
       curl -fLo "$plug_vim" --create-dirs \
-        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
+        https://raw.githubusercontent.com/junegunn/vim-plug/88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim \
         2>&1 || { echo "  WARNING: vim-plug bootstrap failed; skipping vim."; }
     else
       echo "  WARNING: curl not found; cannot bootstrap vim-plug. Skipping vim."

--- a/tests/bash/fixtures/55-setup-editors.sh
+++ b/tests/bash/fixtures/55-setup-editors.sh
@@ -27,7 +27,7 @@ if command -v vim &>/dev/null; then
     if command -v curl &>/dev/null; then
       echo "  Bootstrapping vim-plug..."
       curl -fLo "$plug_vim" --create-dirs \
-        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
+        https://raw.githubusercontent.com/junegunn/vim-plug/88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim \
         2>&1 || { echo "  WARNING: vim-plug bootstrap failed; skipping vim."; }
     else
       echo "  WARNING: curl not found; cannot bootstrap vim-plug. Skipping vim."

--- a/tests/powershell/55-setup-editors.Tests.ps1
+++ b/tests/powershell/55-setup-editors.Tests.ps1
@@ -104,11 +104,11 @@ Describe 'setup-editors' {
     It 'resolves curl.exe explicitly (bypassing the PS5.1 curl alias) and bootstraps vim-plug' {
       $output = & pwsh -NoProfile -Command "
         function Get-Command {
-          param([string]`$Name, [string]`$ErrorAction)
+          param([string]`$Name, [string]`$CommandType, [string]`$ErrorAction)
           if (`$Name -eq 'vim') {
             [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
           } elseif (`$Name -eq 'curl.exe') {
-            [pscustomobject]@{ Name = 'curl.exe'; Source = '/mock/curl.exe' }
+            [pscustomobject]@{ Name = 'curl.exe'; Path = 'curl.exe'; Source = 'curl.exe' }
           } else { `$null }
         }
         function curl.exe {
@@ -130,7 +130,7 @@ Describe 'setup-editors' {
     It 'falls back to Invoke-WebRequest when curl.exe is not available' {
       $output = & pwsh -NoProfile -Command "
         function Get-Command {
-          param([string]`$Name, [string]`$ErrorAction)
+          param([string]`$Name, [string]`$CommandType, [string]`$ErrorAction)
           if (`$Name -eq 'vim') {
             [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
           } else { `$null }
@@ -154,7 +154,7 @@ Describe 'setup-editors' {
     It 'warns and does not throw when Invoke-WebRequest fails' {
       $output = & pwsh -NoProfile -Command "
         function Get-Command {
-          param([string]`$Name, [string]`$ErrorAction)
+          param([string]`$Name, [string]`$CommandType, [string]`$ErrorAction)
           if (`$Name -eq 'vim') {
             [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
           } else { `$null }

--- a/tests/powershell/55-setup-editors.Tests.ps1
+++ b/tests/powershell/55-setup-editors.Tests.ps1
@@ -108,10 +108,14 @@ Describe 'setup-editors' {
           if (`$Name -eq 'vim') {
             [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
           } elseif (`$Name -eq 'curl.exe') {
+            `$global:curlResolvedViaGetCommand = `$true
             [pscustomobject]@{ Name = 'curl.exe'; Path = 'curl.exe'; Source = 'curl.exe' }
           } else { `$null }
         }
         function curl.exe {
+          if (-not `$global:curlResolvedViaGetCommand) {
+            throw 'curl.exe invoked without resolving it via Get-Command first'
+          }
           Write-Host ('curl-args:' + (`$args -join ' '))
           `$global:LASTEXITCODE = 0
         }

--- a/tests/powershell/55-setup-editors.Tests.ps1
+++ b/tests/powershell/55-setup-editors.Tests.ps1
@@ -100,6 +100,58 @@ Describe 'setup-editors' {
     }
   }
 
+  Context 'vim-plug bootstrap on PS5.1-safe curl resolution' {
+    It 'resolves curl.exe explicitly (bypassing the PS5.1 curl alias) and bootstraps vim-plug' {
+      $output = & pwsh -NoProfile -Command "
+        function Get-Command {
+          param([string]`$Name, [string]`$ErrorAction)
+          if (`$Name -eq 'vim') {
+            [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
+          } elseif (`$Name -eq 'curl.exe') {
+            [pscustomobject]@{ Name = 'curl.exe'; Source = '/mock/curl.exe' }
+          } else { `$null }
+        }
+        function curl.exe {
+          Write-Host ('curl-args:' + (`$args -join ' '))
+          `$global:LASTEXITCODE = 0
+        }
+        function vim { `$global:LASTEXITCODE = 0 }
+        `$env:HOME = '$($script:TempDir -replace "'","''")'
+        Set-Variable -Name HOME -Value `$env:HOME -Scope Global -Force
+        & '$($script:Fixture -replace "'","''")'
+      " 2>&1
+
+      $text = $output | Out-String
+      $text | Should -BeLike '*Bootstrapping vim-plug...*'
+      $text | Should -BeLike '*curl-args:*vim-plug*plug.vim*'
+      $text | Should -Not -BeLike '*Invoke-WebRequest*'
+    }
+
+    It 'falls back to Invoke-WebRequest when curl.exe is not available' {
+      $output = & pwsh -NoProfile -Command "
+        function Get-Command {
+          param([string]`$Name, [string]`$ErrorAction)
+          if (`$Name -eq 'vim') {
+            [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
+          } else { `$null }
+        }
+        function Invoke-WebRequest {
+          param([string]`$Uri, [string]`$OutFile, [switch]`$UseBasicParsing)
+          Write-Host ('iwr-called:' + `$Uri)
+          Set-Content -Path `$OutFile -Value 'fake plug.vim content'
+        }
+        function vim { `$global:LASTEXITCODE = 0 }
+        `$env:HOME = '$($script:TempDir -replace "'","''")'
+        Set-Variable -Name HOME -Value `$env:HOME -Scope Global -Force
+        & '$($script:Fixture -replace "'","''")'
+      " 2>&1
+
+      $text = $output | Out-String
+      $text | Should -BeLike '*Bootstrapping vim-plug via Invoke-WebRequest*'
+      $text | Should -BeLike '*iwr-called:*vim-plug*plug.vim*'
+    }
+  }
+
   Context 'nvim lazy.nvim sync' {
     It 'runs nvim headless sync when nvim is available' {
       # XDG_DATA_HOME directs lazydir under the temp tree so the mock

--- a/tests/powershell/55-setup-editors.Tests.ps1
+++ b/tests/powershell/55-setup-editors.Tests.ps1
@@ -136,7 +136,7 @@ Describe 'setup-editors' {
           } else { `$null }
         }
         function Invoke-WebRequest {
-          param([string]`$Uri, [string]`$OutFile, [switch]`$UseBasicParsing)
+          param([string]`$Uri, [string]`$OutFile, [switch]`$UseBasicParsing, [string]`$ErrorAction)
           Write-Host ('iwr-called:' + `$Uri)
           Set-Content -Path `$OutFile -Value 'fake plug.vim content'
         }
@@ -149,6 +149,27 @@ Describe 'setup-editors' {
       $text = $output | Out-String
       $text | Should -BeLike '*Bootstrapping vim-plug via Invoke-WebRequest*'
       $text | Should -BeLike '*iwr-called:*vim-plug*plug.vim*'
+    }
+
+    It 'warns and does not throw when Invoke-WebRequest fails' {
+      $output = & pwsh -NoProfile -Command "
+        function Get-Command {
+          param([string]`$Name, [string]`$ErrorAction)
+          if (`$Name -eq 'vim') {
+            [pscustomobject]@{ Name = 'vim'; Source = '/mock/vim' }
+          } else { `$null }
+        }
+        function Invoke-WebRequest {
+          param([string]`$Uri, [string]`$OutFile, [switch]`$UseBasicParsing, [string]`$ErrorAction)
+          throw 'simulated network failure'
+        }
+        `$env:HOME = '$($script:TempDir -replace "'","''")'
+        Set-Variable -Name HOME -Value `$env:HOME -Scope Global -Force
+        & '$($script:Fixture -replace "'","''")'
+      " 2>&1
+
+      $text = $output | Out-String
+      $text | Should -BeLike '*WARNING: vim-plug bootstrap failed; skipping vim.*'
     }
   }
 

--- a/tests/powershell/fixtures/55-setup-editors.ps1
+++ b/tests/powershell/fixtures/55-setup-editors.ps1
@@ -42,10 +42,11 @@ if ($vimCmd) {
       New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
     }
 
-    $curlExeCmd = Get-Command curl.exe -ErrorAction SilentlyContinue
+    $curlExeCmd = Get-Command curl.exe -CommandType Application -ErrorAction SilentlyContinue
     if ($curlExeCmd) {
       Write-Host '  Bootstrapping vim-plug...'
-      & curl.exe -fLo $plugVim --create-dirs $plugUrl 2>&1
+      $curlExePath = if ($curlExeCmd.Path) { $curlExeCmd.Path } else { $curlExeCmd.Source }
+      & $curlExePath -fLo $plugVim --create-dirs $plugUrl 2>&1
       if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }

--- a/tests/powershell/fixtures/55-setup-editors.ps1
+++ b/tests/powershell/fixtures/55-setup-editors.ps1
@@ -31,20 +31,31 @@ if ($vimCmd) {
   }
 
   if (-not (Test-Path $plugVim)) {
-    $curlCmd = Get-Command curl -ErrorAction SilentlyContinue
-    if ($curlCmd) {
+    # On Windows PowerShell 5.1, "curl" is a built-in alias for
+    # Invoke-WebRequest, so Get-Command curl matches the alias
+    # instead of the real binary and parameter binding fails.
+    # Resolve curl.exe explicitly (extension bypasses alias
+    # resolution) and fall back to Invoke-WebRequest when absent.
+    $plugUrl = 'https://raw.githubusercontent.com/junegunn/vim-plug/88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim'
+    $plugDir = Split-Path $plugVim -Parent
+    if (-not (Test-Path $plugDir)) {
+      New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
+    }
+
+    $curlExeCmd = Get-Command curl.exe -ErrorAction SilentlyContinue
+    if ($curlExeCmd) {
       Write-Host '  Bootstrapping vim-plug...'
-      $plugDir = Split-Path $plugVim -Parent
-      if (-not (Test-Path $plugDir)) {
-        New-Item -ItemType Directory -Path $plugDir -Force | Out-Null
-      }
-      & curl -fLo $plugVim --create-dirs `
-        'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim' 2>&1
+      & curl.exe -fLo $plugVim --create-dirs $plugUrl 2>&1
       if ($LASTEXITCODE -ne 0) {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }
     } else {
-      Write-Host '  WARNING: curl not found; cannot bootstrap vim-plug. Skipping vim.'
+      Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
+      try {
+        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing
+      } catch {
+        Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
+      }
     }
   }
 

--- a/tests/powershell/fixtures/55-setup-editors.ps1
+++ b/tests/powershell/fixtures/55-setup-editors.ps1
@@ -52,13 +52,18 @@ if ($vimCmd) {
       }
     } else {
       Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
+      # PS5.1's .NET default protocol set can exclude TLS 1.2, which
+      # GitHub's raw content endpoint requires. Add it without
+      # dropping whatever protocols were already enabled, and scope
+      # the change to this call only.
+      $prevProtocol = [Net.ServicePointManager]::SecurityProtocol
       try {
-        # PS5.1's .NET default protocol set can exclude TLS 1.2, which
-        # GitHub's raw content endpoint requires.
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        [Net.ServicePointManager]::SecurityProtocol = $prevProtocol -bor [Net.SecurityProtocolType]::Tls12
         Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing -ErrorAction Stop
       } catch {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
+      } finally {
+        [Net.ServicePointManager]::SecurityProtocol = $prevProtocol
       }
     }
   }

--- a/tests/powershell/fixtures/55-setup-editors.ps1
+++ b/tests/powershell/fixtures/55-setup-editors.ps1
@@ -52,7 +52,10 @@ if ($vimCmd) {
     } else {
       Write-Host '  Bootstrapping vim-plug via Invoke-WebRequest...'
       try {
-        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing
+        # PS5.1's .NET default protocol set can exclude TLS 1.2, which
+        # GitHub's raw content endpoint requires.
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $plugUrl -OutFile $plugVim -UseBasicParsing -ErrorAction Stop
       } catch {
         Write-Host "  WARNING: vim-plug bootstrap failed; skipping vim."
       }


### PR DESCRIPTION
## Summary

The vim-plug bootstrap had two defects:

1. `home/run_onchange_after_55-setup-editors.ps1.tmpl` invoked bare
   `curl`. Under Windows PowerShell 5.1, `curl` is a built-in alias
   for `Invoke-WebRequest`, so `Get-Command curl` matched the alias
   and `& curl -fLo … --create-dirs …` failed on parameter binding.
   On a fresh Windows machine with vim installed, the first `chezmoi
   apply` never installed vim-plug.
2. Both variants downloaded `plug.vim` from the unpinned
   `raw.githubusercontent.com/junegunn/vim-plug/master/...` URL —
   executable vimscript from a moving branch.

Fixes:

- Resolve `curl.exe` explicitly (`Get-Command curl.exe` — the `.exe`
  extension bypasses PowerShell's alias resolution) with an
  `Invoke-WebRequest -UseBasicParsing` fallback (PS5.1-safe syntax)
  when it's absent.
- Pinned the `plug.vim` raw URL to upstream `junegunn/vim-plug`
  commit `88e31471818e9a29a8a20a0ee61360cfd7bdc1cd` (2026-05-22,
  latest `master` HEAD at implementation time) in `home/dot_vimrc`
  and both platform variants of the setup script. No
  `vim-plug/master/` reference remains under `home/`.
- Added Pester coverage for the curl.exe resolution and
  Invoke-WebRequest fallback paths.

Closes #158

## Functional evidence

Verified `88e31471818e9a29a8a20a0ee61360cfd7bdc1cd/plug.vim` resolves
(`HTTP 200`) via the pinned raw URL. Verified via `git stash`
round-trips that the two new Pester cases fail against the pre-fix
fixture (confirming they exercise the PS5.1 alias-shadowing bug) and
pass after the fix.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 242/242
      passing
- [x] `pwsh -c "Invoke-Pester tests/powershell/55-setup-editors.Tests.ps1"`
      — 8/8 passing (2 new, both verified to fail pre-fix)
- [x] Manual URL reachability check (see above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vim plugin setup compatibility with Windows PowerShell 5.1 by avoiding `curl` alias conflicts.
  * Added a fallback download method when `curl.exe` is unavailable.
  * Pinned plugin bootstrap downloads to a specific version for more consistent setup.

* **Tests**
  * Added coverage for both the `curl.exe` download path and the PowerShell fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->