### PR TITLE
fix(pwsh): ps5.1-safe $IsWindows guards in cargo and deploy-state

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -50,6 +50,7 @@ words:
   - taskrc
   - unpushed
   - unreplied
+  - upserts
   - waivable
   - wgetrc
   - viml

--- a/home/dot_config/powershell/conf.d/02-cargo.ps1
+++ b/home/dot_config/powershell/conf.d/02-cargo.ps1
@@ -9,7 +9,7 @@
 # "rustup-init --no-modify-path" without losing PATH integration and
 # without rustup mutating chezmoi-managed shell rc files.
 
-if ($IsWindows) { return }
+if ($IsWindows -ne $false) { return }
 
 & {
   $cargoHome = if ([string]::IsNullOrEmpty($env:CARGO_HOME)) {

--- a/home/dot_local/bin/executable_secret-deploy-state.ps1
+++ b/home/dot_local/bin/executable_secret-deploy-state.ps1
@@ -49,7 +49,7 @@ function Write-Warn([string]$Message) {
 
 function Get-FileMode {
   param([string]$Path)
-  if ($IsWindows) { return '' }
+  if ($IsWindows -ne $false) { return '' }
   try {
     $r = & stat -c '%a' $Path 2>$null
     if (-not $r) { $r = & stat -f '%A' $Path 2>$null }
@@ -59,7 +59,7 @@ function Get-FileMode {
 
 function Set-RestrictedAcl {
   param([string]$Path)
-  if ($IsWindows -and $env:USERNAME) {
+  if ($IsWindows -ne $false -and $env:USERNAME) {
     & icacls $Path /inheritance:r /grant:r "${env:USERNAME}:(R,W)" 2>&1 | Out-Null
   } elseif ($IsWindows -eq $false) {
     & chmod 600 $Path 2>$null | Out-Null

--- a/tests/powershell/02-cargo.Tests.ps1
+++ b/tests/powershell/02-cargo.Tests.ps1
@@ -73,3 +73,33 @@ Describe '02-cargo (Unix pwsh)' -Skip:($IsWindows -eq $true) {
     $env:PATH.Split([IO.Path]::PathSeparator)[0] | Should -Be $altBin
   }
 }
+
+Describe '02-cargo (PS5.1 $IsWindows guard)' {
+
+  # $IsWindows is a ReadOnly, AllScope automatic variable: Set-Variable
+  # -Force can override it, but AllScope means the override leaks
+  # process-wide rather than staying scoped to a block. Simulate PS5.1
+  # (where $IsWindows is $null) in a throwaway subprocess instead of
+  # mutating the current Pester process.
+  It 'returns before touching $env:PATH when $IsWindows is $null (PS5.1 emulation)' {
+    # A real $HOME/.cargo/bin must exist so a wrongly-taken Unix branch
+    # has something to prepend; otherwise the script's own "directory
+    # missing" no-op would mask the guard bug and the test would pass
+    # even against the pre-fix code.
+    $home51 = (New-Item -ItemType Directory `
+        -Path (Join-Path ([IO.Path]::GetTempPath()) ([Guid]::NewGuid().Guid)) -Force).FullName
+    New-Item -ItemType Directory -Path (Join-Path $home51 '.cargo/bin') -Force | Out-Null
+
+    try {
+      $cmd = "Set-Variable -Name IsWindows -Value `$null -Force; " +
+        "Set-Variable -Name HOME -Value '$home51' -Force; " +
+        "`$env:PATH = '/usr/bin:/bin'; `$before = `$env:PATH; . '$script:Subject'; " +
+        "if (`$env:PATH -eq `$before) { 'UNCHANGED' } else { 'CHANGED' }"
+      $result = (& pwsh -NoLogo -NoProfile -Command $cmd 2>&1 | Select-Object -Last 1)
+
+      $result | Should -Be 'UNCHANGED'
+    } finally {
+      Remove-Item -LiteralPath $home51 -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+}

--- a/tests/powershell/02-cargo.Tests.ps1
+++ b/tests/powershell/02-cargo.Tests.ps1
@@ -91,9 +91,15 @@ Describe '02-cargo (PS5.1 $IsWindows guard)' {
     New-Item -ItemType Directory -Path (Join-Path $home51 '.cargo/bin') -Force | Out-Null
 
     try {
+      # Single-quote-escape interpolated paths: a real-world temp path
+      # can contain an apostrophe (e.g. a Windows username like
+      # O'Connor), which would otherwise break the generated -Command
+      # string before it ever exercises the guard logic.
+      $home51Q = "'" + ($home51 -replace "'", "''") + "'"
+      $subjectQ = "'" + ($script:Subject -replace "'", "''") + "'"
       $cmd = "Set-Variable -Name IsWindows -Value `$null -Force; " +
-        "Set-Variable -Name HOME -Value '$home51' -Force; " +
-        "`$env:PATH = '/usr/bin:/bin'; `$before = `$env:PATH; . '$script:Subject'; " +
+        "Set-Variable -Name HOME -Value $home51Q -Force; " +
+        "`$env:PATH = '/usr/bin:/bin'; `$before = `$env:PATH; . $subjectQ; " +
         "if (`$env:PATH -eq `$before) { 'UNCHANGED' } else { 'CHANGED' }"
       $result = (& pwsh -NoLogo -NoProfile -Command $cmd 2>&1 | Select-Object -Last 1)
 

--- a/tests/powershell/secret-deploy-state.Tests.ps1
+++ b/tests/powershell/secret-deploy-state.Tests.ps1
@@ -3,6 +3,16 @@
 BeforeAll {
   $script:ScriptPath = Join-Path $PSScriptRoot '..' '..' 'home' 'dot_local' 'bin' 'executable_secret-deploy-state.ps1'
 
+  # A real-world path can contain an apostrophe (e.g. a Windows
+  # username like O'Connor), which would otherwise break the
+  # generated -Command string before it ever reaches the script under
+  # test. Every value interpolated into a single-quoted segment below
+  # goes through this.
+  function script:ConvertTo-PSSingleQuoted {
+    param([string]$Value)
+    "'" + ($Value -replace "'", "''") + "'"
+  }
+
   # Run the helper in a fresh pwsh subprocess so we can isolate $env:HOME
   # and capture both stdout and stderr.
   function script:Invoke-Helper {
@@ -24,13 +34,15 @@ BeforeAll {
     $stubBlock = ''
     if ($SimulatePS51) { $stubBlock += "Set-Variable -Name IsWindows -Value `$null -Force;" }
     if ($IcaclsMarkerPath) {
-      $stubBlock += "function icacls { `$args -join ' ' | Out-File -FilePath '$IcaclsMarkerPath' -Append };"
+      $markerQ = ConvertTo-PSSingleQuoted $IcaclsMarkerPath
+      $stubBlock += "function icacls { `$args -join ' ' | Out-File -FilePath $markerQ -Append };"
     }
     $envBlock = ''
-    if ($HomeDir) { $envBlock += "`$env:HOME = '$HomeDir';" }
-    foreach ($k in $ExtraEnv.Keys) { $envBlock += "`$env:$k = '$($ExtraEnv[$k])';" }
-    $argsExpr = ($ScriptArgs | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ' '
-    $cmd = "$stubBlock$envBlock & '$script:ScriptPath' $argsExpr 2>&1; exit `$LASTEXITCODE"
+    if ($HomeDir) { $envBlock += "`$env:HOME = $(ConvertTo-PSSingleQuoted $HomeDir);" }
+    foreach ($k in $ExtraEnv.Keys) { $envBlock += "`$env:$k = $(ConvertTo-PSSingleQuoted $ExtraEnv[$k]);" }
+    $argsExpr = ($ScriptArgs | ForEach-Object { ConvertTo-PSSingleQuoted $_ }) -join ' '
+    $scriptPathQ = ConvertTo-PSSingleQuoted $script:ScriptPath
+    $cmd = "$stubBlock$envBlock & $scriptPathQ $argsExpr 2>&1; exit `$LASTEXITCODE"
     $output = & pwsh -NoLogo -NoProfile -Command $cmd 2>&1
     return @{ Output = ($output -join "`n"); ExitCode = $LASTEXITCODE }
   }

--- a/tests/powershell/secret-deploy-state.Tests.ps1
+++ b/tests/powershell/secret-deploy-state.Tests.ps1
@@ -9,13 +9,28 @@ BeforeAll {
     param(
       [string]   $HomeDir,
       [string[]] $ScriptArgs = @(),
-      [hashtable]$ExtraEnv = @{}
+      [hashtable]$ExtraEnv = @{},
+      # $IsWindows is ReadOnly+AllScope: Set-Variable -Force can stub it,
+      # but the override leaks process-wide. Only ever apply it inside
+      # this throwaway subprocess, never in the Pester process itself.
+      [switch]   $SimulatePS51,
+      # icacls does not exist on Linux/macOS CI. A PowerShell function
+      # resolves before an external command of the same name, so
+      # defining one here shims the call on every platform (including
+      # real Windows, where it just shadows the real binary for this
+      # one test) without needing a real icacls on PATH.
+      [string]   $IcaclsMarkerPath
     )
+    $stubBlock = ''
+    if ($SimulatePS51) { $stubBlock += "Set-Variable -Name IsWindows -Value `$null -Force;" }
+    if ($IcaclsMarkerPath) {
+      $stubBlock += "function icacls { `$args -join ' ' | Out-File -FilePath '$IcaclsMarkerPath' -Append };"
+    }
     $envBlock = ''
     if ($HomeDir) { $envBlock += "`$env:HOME = '$HomeDir';" }
     foreach ($k in $ExtraEnv.Keys) { $envBlock += "`$env:$k = '$($ExtraEnv[$k])';" }
     $argsExpr = ($ScriptArgs | ForEach-Object { "'" + ($_ -replace "'", "''") + "'" }) -join ' '
-    $cmd = "$envBlock & '$script:ScriptPath' $argsExpr 2>&1; exit `$LASTEXITCODE"
+    $cmd = "$stubBlock$envBlock & '$script:ScriptPath' $argsExpr 2>&1; exit `$LASTEXITCODE"
     $output = & pwsh -NoLogo -NoProfile -Command $cmd 2>&1
     return @{ Output = ($output -join "`n"); ExitCode = $LASTEXITCODE }
   }
@@ -138,5 +153,32 @@ Describe 'secret-deploy-state.ps1' {
     $h = New-FreshHome
     $r = Invoke-Helper -HomeDir $h -ScriptArgs @('gibberish')
     $r.ExitCode | Should -Be 2
+  }
+}
+
+Describe 'secret-deploy-state.ps1 (PS5.1 $IsWindows guard)' {
+
+  It 'takes the icacls branch and leaves mode empty when $IsWindows is $null (PS5.1 emulation)' {
+    $h = New-FreshHome
+    $f = Join-Path $h '.secret/ps51.txt'
+    New-File -Path $f -Content 'abc'
+    $marker = Join-Path ([System.IO.Path]::GetTempPath()) ("icacls-marker-" + [Guid]::NewGuid().ToString('N') + '.txt')
+
+    try {
+      $r = Invoke-Helper -HomeDir $h -ScriptArgs @('record', 'secretFile', 'ps51', $f) `
+        -ExtraEnv @{ USERNAME = 'testuser' } -SimulatePS51 -IcaclsMarkerPath $marker
+
+      $r.ExitCode | Should -Be 0
+      # Proves the icacls branch ran instead of the pre-fix silent no-op.
+      Test-Path -LiteralPath $marker | Should -BeTrue
+
+      $j = Get-Content -LiteralPath (Get-StateFor -HomeDir $h) -Raw | ConvertFrom-Json
+      $entry = $j.entries | Where-Object { $_.path -eq $f } | Select-Object -First 1
+      $entry             | Should -Not -BeNullOrEmpty
+      # Proves Get-FileMode returned '' instead of shelling out to stat.
+      $entry.mode        | Should -BeNullOrEmpty
+    } finally {
+      Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+    }
   }
 }


### PR DESCRIPTION
## Summary

Windows PowerShell 5.1 never sets `$IsWindows` (it stays `$null`), so
the bare `if ($IsWindows)` guards in `02-cargo.ps1` and
`executable_secret-deploy-state.ps1` silently took the Unix branch on
PS5.1:

- `02-cargo.ps1` ran the Unix Cargo-PATH prepend logic on Windows.
- `Get-FileMode` shelled out to `stat` instead of returning `''`.
- `Set-RestrictedAcl` skipped both the `icacls` and `chmod` branches
  entirely (silent no-op — no ACL hardening applied at all).

Converted all three guards to the null-safe `-ne $false` / `-eq
$false` idiom already used in `01-path.ps1` and `30-mise.ps1`.

## Test strategy

`$IsWindows` is a `ReadOnly, AllScope` automatic variable —
overridable with `Set-Variable -Force`, but the override is
process-wide, not scoped to a block. The new assertions therefore run
in an isolated `pwsh -NoProfile` subprocess per test rather than
mutating `$IsWindows` in the Pester process itself:

- `02-cargo.Tests.ps1`: asserts the script returns before touching
  `$env:PATH`. Uses a real `$HOME/.cargo/bin` under an isolated `$HOME`
  so a wrongly-taken Unix branch has something to prepend — otherwise
  the script's own "directory missing" no-op would mask the guard bug.
- `secret-deploy-state.Tests.ps1`: since no real `icacls` binary exists
  on Linux/macOS CI, the new test defines a PowerShell **function**
  named `icacls` ahead of the script invocation (functions resolve
  before external commands, so this shims the call on every platform,
  including real Windows CI). Asserts the shim was invoked (proving
  the icacls branch — not the silent no-op — was taken) and that the
  recorded `mode` field is empty (proving `Get-FileMode` returned `''`
  instead of shelling out to `stat`).

Confirmed each new assertion fails against the pre-fix guards via a
`git stash` round-trip on the two source files.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 242/242 passing
- [x] `pwsh -c "Invoke-Pester tests/powershell/"` — new/touched files
      (`02-cargo.Tests.ps1`, `secret-deploy-state.Tests.ps1`) pass in
      full; full-suite run also shows 5 pre-existing failures
      unrelated to this change (`Assert-MockCalled` not available
      under the locally installed Pester v6, and unrelated
      `40-fzf.Tests.ps1` mock leakage) — reproduced identically on
      unmodified `master`, so not introduced by this PR
- [x] Verified new assertions fail pre-fix / pass post-fix via `git stash`

Closes #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PowerShell behavior when Windows detection is unavailable or indeterminate.
  * Hardened permission handling across Windows and non-Windows environments.
  * Ensured deployment state recording applies the appropriate file permissions reliably.

* **Tests**
  * Added coverage for PowerShell 5.1 compatibility and missing Windows detection.
  * Expanded validation for permission handling and environment values containing special characters.

* **Chores**
  * Added `upserts` to the spelling allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->