### PR TITLE
fix(ci): exempt IDD lifecycle labels from StaleBot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
           days-before-stale: 60
           close-issue-message: StaleBot closed the issue due to prolonged inactivity.
           close-pr-message: StaleBot closed the pull request due to prolonged inactivity.
-          exempt-issue-labels: bug,enhancement
+          exempt-issue-labels: bug,enhancement,idd-task,roadmap,status:blocked-by-human,status:needs-decision,status:authoring
           exempt-pr-labels: bug,enhancement
           stale-issue-label: stale
           stale-issue-message: StaleBot marked the issue as stale because there has been no activity.


### PR DESCRIPTION
Closes #164.

## Summary
- Extends `exempt-issue-labels` in `.github/workflows/stale.yml` from `bug,enhancement` to also include `idd-task,roadmap,status:blocked-by-human,status:needs-decision,status:authoring`, so IDD lifecycle issues (backlog items, roadmap umbrellas, and human-hold states) are no longer eligible for silent auto-close after 60+14 days of inactivity.
- `exempt-pr-labels` and all timing values are left unchanged, per the issue's proposed change.

## Test plan
- [x] Validated the workflow YAML parses correctly (`npx js-yaml .github/workflows/stale.yml`) and the resulting `with.exempt-issue-labels` value is exactly as intended, `exempt-pr-labels` unchanged.
- [x] `cspell` passes on the changed file.
- [ ] CI lint job passes on this PR (cspell + markdownlint; this change touches neither markdown nor spelling-sensitive content beyond what cspell already validated locally).