### PR TITLE
chore(deps): let dependabot update the bats git submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: monthly
+  - directory: /
+    labels:
+      - dependencies
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Closes #167.

## Summary
- Adds a `package-ecosystem: gitsubmodule` update block to `.github/dependabot.yml` (`directory: /`), matching the existing github-actions block's `labels: [dependencies]` and `schedule.interval: monthly` cadence, so the four `tests/bash/helpers/{bats-core,bats-support,bats-assert,bats-file}` git-submodule dependencies get update PRs instead of drifting silently.
- Note: the issue text mentions a "weekly cadence style" but the actual existing github-actions block already uses `monthly` — matched the real block's cadence per the acceptance criteria ("same... cadence style as the existing github-actions block"), not the issue's stale description.

## Test plan
- [x] Validated the YAML parses correctly (`npx js-yaml .github/dependabot.yml`) and the new block's structure matches the schema shape of the existing block.
- [x] `cspell` passes on the changed file.
- [ ] CI lint job passes on this PR.
- [ ] Dependabot tab shows the new ecosystem without config errors after merge (only verifiable post-merge).