### PR TITLE
fix(ci): fail the Lua syntax job when no Lua files are found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,26 @@ jobs:
       - name: Check Lua syntax
         shell: bash
         run: |
+          if [ ! -d home/dot_config/nvim ]; then
+            echo "::error::home/dot_config/nvim directory not found"
+            exit 1
+          fi
+
           errors=0
+          checked=0
           while IFS= read -r -d '' f; do
+            checked=$((checked + 1))
             if ! luac -p "$f"; then
               errors=$((errors + 1))
             fi
           done < <(find home/dot_config/nvim -name '*.lua' -print0)
+
+          echo "Checked $checked Lua file(s)"
+
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::No Lua files found under home/dot_config/nvim"
+            exit 1
+          fi
           if [ "$errors" -gt 0 ]; then
             echo "::error::$errors Lua file(s) have syntax errors"
             exit 1


### PR DESCRIPTION
Closes #168.

## Summary
- The `Lua syntax check` job's `find home/dot_config/nvim … | while read` loop silently exits 0 when the directory is renamed/removed or ends up with zero `.lua` files — `find` fails or returns nothing, the loop runs zero iterations, `errors` stays `0`. Currently latent (13 files present today).
- Added an up-front directory-exists assertion, a `checked` file counter logged every run, and an explicit `exit 1` when `checked -eq 0`.

## Test plan
- [x] Local reproduction of the exact step script (see below) against three scenarios:
  - Current `home/dot_config/nvim` content: passes, logs `Checked 13 Lua file(s)`.
  - `home/dot_config/nvim` renamed away: fails with `::error::home/dot_config/nvim directory not found`.
  - `home/dot_config/nvim` present but empty of `.lua` files (the actual latent false-green bug): fails with `::error::No Lua files found under home/dot_config/nvim`.
- [x] `cspell` and YAML-parse validation pass on the changed workflow file.
- [ ] CI lint/lua-syntax jobs pass on this PR (exercises the "current content still passes" path for real).