### PR TITLE
docs: remove stale worktree claims from agent entry files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,22 +6,6 @@ When contributing to this repository using AI agents, adhere to the
 following guidelines to ensure high-quality contributions that align with
 the project's standards and practices:
 
-## Repository architecture
-
-This repository is a **git worktree** of
-[kurone-kito/dotfiles](https://github.com/kurone-kito/dotfiles),
-checked out on the `migrate-to-chezmoi` branch. The directory name
-`dotfiles.migrate-to-chezmoi` reflects the branch name, not a
-separate repository.
-
-- **Remote origin:** `kurone-kito/dotfiles`
-- **Branch:** `migrate-to-chezmoi`
-- **CI badges and workflow URLs** correctly reference
-  `kurone-kito/dotfiles`
-
-Do not treat this as a standalone repository or suggest renaming
-remote URLs or badge links.
-
 ## Tooling priority and compatibility
 
 This repository is intentionally optimized for GitHub Copilot CLI and
@@ -290,8 +274,9 @@ feat: add auth system and refactor database layer and update docs
   `.gitattributes`)
 - **Trailing whitespace**: trimmed (except in Markdown)
 - **Final newline**: always present
-- **File naming**: lowercase with hyphens (e.g., `feature-request.yml`)
-  unless constrained by a platform convention (e.g., `CONTRIBUTING.md`)
+- **File naming**: lowercase with hyphens (e.g., `getting-started.md`)
+  unless constrained by a platform convention (e.g., `CONTRIBUTING.md`,
+  or GitHub's underscore-based `.github/ISSUE_TEMPLATE/feature_request.yml`)
 
 ### PowerShell profile
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,6 @@
 # Guidelines for AI Agents
 
 A collection of configuration files that we use.
-This is a **git worktree** of
-[kurone-kito/dotfiles](https://github.com/kurone-kito/dotfiles) on
-the `migrate-to-chezmoi` branch — not a separate repository. CI
-badges and workflow URLs correctly reference `kurone-kito/dotfiles`.
 
 It is currently optimized for GitHub Copilot tooling, but `AGENTS.md`
 exists so Codex can still receive the minimum project rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,6 @@
 # Guidelines for AI Agents
 
 A collection of configuration files that we use.
-This is a **git worktree** of
-[kurone-kito/dotfiles](https://github.com/kurone-kito/dotfiles) on
-the `migrate-to-chezmoi` branch — not a separate repository. CI
-badges and workflow URLs correctly reference `kurone-kito/dotfiles`.
 
 It is currently optimized for GitHub Copilot tooling, but `CLAUDE.md`
 exists so Claude Code can still receive the minimum project rules

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,10 +1,6 @@
 # Guidelines for AI Agents
 
 A collection of configuration files that we use.
-This is a **git worktree** of
-[kurone-kito/dotfiles](https://github.com/kurone-kito/dotfiles) on
-the `migrate-to-chezmoi` branch — not a separate repository. CI
-badges and workflow URLs correctly reference `kurone-kito/dotfiles`.
 
 It is currently optimized for GitHub Copilot tooling, but `GEMINI.md`
 exists so Gemini CLI can still receive the minimum project rules
@@ -97,22 +93,6 @@ Always report which path (GPG / GPG-after-restart / `git commit-ssh`
 alias / transient SSH / unsigned) was used; when unsigned, disclose
 the GPG cause, whether the gpg-agent restart was attempted or
 skipped (and why), and the SSH cause.
-
-## Onboarding detection
-
-When starting a session, check whether this repository is the base
-template or a derived project:
-
-- If the repository name is exactly `template`, it is the base
-  template — no action needed.
-- If the name differs **and** this file still contains the phrase
-  `language-independent generic project template`, the guidelines
-  have not been customized yet.
-
-In that case, **proactively propose an onboarding workflow** to
-customize the project's documentation, tooling, and AI guidelines.
-See the full onboarding checklist in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
 
 ## IDD Workflow
 

--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -2,7 +2,7 @@
 
 This repository currently prioritizes GitHub Copilot because it
 provides the best latency and workflow fit for day-to-day vibe coding
-in this template.
+in this repository.
 
 ## Canonical guidance
 


### PR DESCRIPTION
Progresses #170 (see note below on why this PR does not auto-close it).

## Summary
- Removed the stale "this is a git worktree on migrate-to-chezmoi" framing from `CLAUDE.md`, `AGENTS.md`, `GEMINI.md` intros, and deleted `.github/copilot-instructions.md`'s entire "Repository architecture" section (which existed only to explain that setup, including the "do not treat as standalone" guardrail and a reference to a nonexistent `dotfiles.migrate-to-chezmoi` directory).
- Deleted `GEMINI.md`'s "Onboarding detection" block — a generic-template artifact not present in its siblings, pointing at a nonexistent onboarding checklist, with a self-satisfying trigger phrase.
- Fixed the file-naming example in `copilot-instructions.md` (`feature-request.yml` doesn't exist; the real file is `.github/ISSUE_TEMPLATE/feature_request.yml` with an underscore) — swapped in an existing hyphenated example and named the underscore exception explicitly.
- Reworded `docs/ai-strategy.md`'s "in this template" → "in this repository" (the only stale hit in that file; other "this template" references elsewhere in `docs/` describe the separate, legitimate IDD-skill export/adoption template concept and are untouched).

## Why this doesn't close #170 outright
#170's acceptance criteria requires `npx markdownlint-cli2 "**/*.md"` to pass over the whole tree. That command reports 35 pre-existing errors, all in files this PR never touches (`docs/vscode-terminal.md`, `docs/secret-manager-setup.md`, `docs/sshd-config-setup.md`, `docs/ghq-workflow.md`, `docs/zellij-web-mobile.md`, `.github/instructions/idd-overview.instructions.md`) — confirmed identical on a fresh clone of `master` before this PR's changes. That's the repo-wide lint-scope gap tracked by #165 ("CI's markdownlint step lints only the 5 root-level files of 64 tracked markdown files"), not something this docs-cleanup PR should absorb. Every change #170 actually asked for is done and verified below; #170 stays open with a comment pointing at the remaining, #165-owned gap.

## Test plan
- [x] `grep -rn 'migrate-to-chezmoi' --include='*.md' .` → zero hits.
- [x] `grep -rn 'language-independent generic project template' --include='*.md' .` → zero hits.
- [x] The file-naming example now matches an existing file and explicitly notes the underscore convention exception.
- [x] `npx markdownlint-cli2` against just the 5 changed files → 0 errors.
- [x] `npx cspell` against the 5 changed files → 0 issues.
- [~] `npx markdownlint-cli2 "**/*.md"` over the whole tree still reports the 35 pre-existing, unrelated errors described above (tracked by #165).