### PR TITLE
fix(ci): lint all markdown files in CI, not just the repository root

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -36,6 +36,7 @@ words:
   - desync
   - Esync
   - exrc
+  - Fira
   - gdefault
   - gpgconf
   - hlsearch

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -14,7 +14,7 @@
   ],
   "commands": {
     "install-deps": "git submodule update --init --recursive",
-    "fix-validate": "npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
+    "fix-validate": "npx markdownlint-cli2 --fix && npx markdownlint-cli2",
     "pre-push-validate": "tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c \"Invoke-Pester tests/powershell/ -Output Detailed\"",
     "post-fix-validate": "tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c \"Invoke-Pester tests/powershell/ -Output Detailed\""
   },

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -36,14 +36,14 @@ the recorded machine-readable policy. Absent values keep the gate
 enabled and default approval actors to
 `owners-and-maintainers-only`.
 
-| Name                    | Commands                                                                                                          |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| **fix-validate**        | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                        |
-| **pre-push-validate**   | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
-| **post-fix-validate**   | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
-| **install-deps**        | `git submodule update --init --recursive`                                                                         |
-| **issue-scope**         | `roadmap`                                                                                                         |
-| **orphan-first-policy** | `none`                                                                                                            |
+| Name | Commands |
+| --- | --- |
+| **fix-validate** | `npx markdownlint-cli2 --fix && npx markdownlint-cli2` |
+| **pre-push-validate** | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
+| **post-fix-validate** | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
+| **install-deps** | `git submodule update --init --recursive` |
+| **issue-scope** | `roadmap` |
+| **orphan-first-policy** | `none` |
 
 Non-shell rows such as **issue-scope** and **orphan-first-policy** are
 workflow settings. Read them literally, not as commands.

--- a/.github/instructions/idd-overview.instructions.md
+++ b/.github/instructions/idd-overview.instructions.md
@@ -36,14 +36,14 @@ the recorded machine-readable policy. Absent values keep the gate
 enabled and default approval actors to
 `owners-and-maintainers-only`.
 
-| Name                    | Commands                         |
-| ----------------------- | -------------------------------- |
-| **fix-validate**        | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`      |
+| Name                    | Commands                                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **fix-validate**        | `npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"`                                        |
 | **pre-push-validate**   | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
 | **post-fix-validate**   | `tests/bash/helpers/bats-core/bin/bats tests/bash/ && pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` |
-| **install-deps**        | `git submodule update --init --recursive`       |
-| **issue-scope**         | `roadmap`                        |
-| **orphan-first-policy** | `none`                           |
+| **install-deps**        | `git submodule update --init --recursive`                                                                         |
+| **issue-scope**         | `roadmap`                                                                                                         |
+| **orphan-first-policy** | `none`                                                                                                            |
 
 Non-shell rows such as **issue-scope** and **orphan-first-policy** are
 workflow settings. Read them literally, not as commands.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,2 +1,6 @@
+globs:
+  - "**/*.{md,markdown}"
 ignores:
   - .github/CODE_OF_CONDUCT*
+  - tests/bash/helpers/**
+  - node_modules/**

--- a/docs/ghq-workflow.md
+++ b/docs/ghq-workflow.md
@@ -6,7 +6,7 @@ identity, and GPG signing key.
 
 ## How the chain works
 
-```
+```text
 ghq get github.com/acme-corp/repo
         │
         ▼
@@ -193,7 +193,7 @@ When a profile has `sshhost` set, the gitconfig template:
 3. Extracts the path after the hostname as the org prefix
 4. Generates `insteadOf` rules for both HTTPS and SSH URLs
 
-```
+```text
 gitdir  = "~/ghq/github.com/acme-corp/"
                   └─────┬─────┘└───┬───┘
                     hostname    org path

--- a/docs/secret-manager-setup.md
+++ b/docs/secret-manager-setup.md
@@ -814,11 +814,11 @@ work even when `mise` / `ghq` are not on `PATH`.
 
 ### Status taxonomy
 
-| Status    | Meaning                                                     |
-| --------- | ----------------------------------------------------------- |
-| `OK`      | Target is present, has the expected mode/ACL, (for GPG) the fingerprint is in the keyring, and (when a deploy fingerprint is recorded) the file content still matches what was last deployed. |
-| `DRIFT`   | Target is present with the correct mode but the SHA-256 of its content no longer matches the fingerprint recorded by the last deploy. Typically caused by a manual edit or by answering `s` (skip) at a chezmoi `has changed since chezmoi last wrote it` prompt. Re-deploy with `chezmoi apply --force` to overwrite, or accept the local edit by re-recording the state (delete the entry from `~/.config/chezmoi/secret-deploy-state.json` and re-run `chezmoi apply`). |
-| `WARN`    | Target is present but with the wrong permissions, or `.gitignore` is missing the env filename, or the SSH host alias is missing the expected `IdentityFile`. Takes precedence over `DRIFT`. |
+| Status | Meaning |
+| --- | --- |
+| `OK` | Target is present, has the expected mode/ACL, (for GPG) the fingerprint is in the keyring, and (when a deploy fingerprint is recorded) the file content still matches what was last deployed. |
+| `DRIFT` | Target is present with the correct mode but the SHA-256 of its content no longer matches the fingerprint recorded by the last deploy. Typically caused by a manual edit or by answering `s` (skip) at a chezmoi `has changed since chezmoi last wrote it` prompt. Re-deploy with `chezmoi apply --force` to overwrite, or accept the local edit by re-recording the state (delete the entry from `~/.config/chezmoi/secret-deploy-state.json` and re-run `chezmoi apply`). |
+| `WARN` | Target is present but with the wrong permissions, or `.gitignore` is missing the env filename, or the SSH host alias is missing the expected `IdentityFile`. Takes precedence over `DRIFT`. |
 | `MISSING` | Target is configured but not deployed. Re-run `chezmoi apply` after fixing the secret-manager entry. |
 | `UNKNOWN` | The check could not run — e.g., `gpg`/`ssh` are not on `PATH`, the manifest lacks an expected fingerprint, or `ghq root` could not be resolved. |
 
@@ -858,7 +858,7 @@ have no recorded fingerprint.
 ### Known limitations
 
 - **Freshness against the secret manager is not checked.**
-  `DRIFT` tells you the file changed _after_ deploy, but it cannot
+  `DRIFT` tells you the file changed *after* deploy, but it cannot
   tell you whether the Bitwarden / 1Password / KeePassXC entry has
   been rotated upstream. Re-run `chezmoi apply` to refresh content
   from the manager.

--- a/docs/sshd-config-setup.md
+++ b/docs/sshd-config-setup.md
@@ -11,11 +11,11 @@ explains how to manually deploy it.
 chezmoi is a **user-level** dotfiles manager. The SSH daemon
 configuration lives in system directories owned by root:
 
-| Platform    | System path                        | Privilege   |
-| ----------- | ---------------------------------- | ----------- |
-| Linux       | `/etc/ssh/sshd_config`             | root        |
-| macOS       | `/etc/ssh/sshd_config`             | root        |
-| Windows     | `C:\ProgramData\ssh\sshd_config`   | Administrator |
+| Platform | System path                      | Privilege     |
+| -------- | -------------------------------- | ------------- |
+| Linux    | `/etc/ssh/sshd_config`           | root          |
+| macOS    | `/etc/ssh/sshd_config`           | root          |
+| Windows  | `C:\ProgramData\ssh\sshd_config` | Administrator |
 
 Automatically escalating to root during `chezmoi apply` would
 violate the principle of least privilege and could break the SSH
@@ -26,17 +26,17 @@ daemon if the configuration is invalid.
 The generated `sshd_config` includes only the settings that differ
 from defaults:
 
-| Setting                 | Value        | Purpose                              |
-| ----------------------- | ------------ | ------------------------------------ |
-| `PasswordAuthentication`| `no`         | Disable password login               |
-| `PermitEmptyPasswords`  | `no`         | Reject empty passwords               |
-| `PermitRootLogin`       | `no`         | Block root SSH access (Unix only)    |
-| `PubkeyAuthentication`  | `yes`        | Enable public key authentication     |
-| `AuthenticationMethods` | `publickey`  | Enforce key-only authentication      |
-| `Subsystem sftp`        | `internal-sftp` | Cross-platform SFTP support       |
-| `ClientAliveInterval`   | `300`        | Keepalive probe interval (seconds)   |
-| `ClientAliveCountMax`   | `5`          | Max missed probes before disconnect  |
-| `TCPKeepAlive`          | `yes`        | Enable TCP-level keepalive           |
+| Setting                  | Value           | Purpose                             |
+| ------------------------ | --------------- | ----------------------------------- |
+| `PasswordAuthentication` | `no`            | Disable password login              |
+| `PermitEmptyPasswords`   | `no`            | Reject empty passwords              |
+| `PermitRootLogin`        | `no`            | Block root SSH access (Unix only)   |
+| `PubkeyAuthentication`   | `yes`           | Enable public key authentication    |
+| `AuthenticationMethods`  | `publickey`     | Enforce key-only authentication     |
+| `Subsystem sftp`         | `internal-sftp` | Cross-platform SFTP support         |
+| `ClientAliveInterval`    | `300`           | Keepalive probe interval (seconds)  |
+| `ClientAliveCountMax`    | `5`             | Max missed probes before disconnect |
+| `TCPKeepAlive`           | `yes`           | Enable TCP-level keepalive          |
 
 The timeout values (`ClientAliveInterval × ClientAliveCountMax`)
 default to approximately 25 minutes, suitable for mobile connections
@@ -261,6 +261,7 @@ If you cannot connect after deploying:
 
 1. Use a local console or out-of-band access (IPMI, cloud console)
 2. Restore the backup:
+
    ```bash
    sudo cp /etc/ssh/sshd_config.bak /etc/ssh/sshd_config
    sudo systemctl reload sshd

--- a/docs/vscode-terminal.md
+++ b/docs/vscode-terminal.md
@@ -29,17 +29,17 @@ The profile detects VS Code's integrated terminal via the
 
 All profile features load in VS Code's integrated terminal:
 
-| Feature    | Status | Notes                             |
-| ---------- | :----: | --------------------------------- |
-| Starship   |   ✅    | Full prompt with transient prompt |
-| zoxide     |   ✅    | `z` directory jumps               |
-| mise       |   ✅    | Runtime version management        |
-| aliases    |   ✅    | `ll`, `which`, etc.               |
-| GPG cache  |   ✅    | Signing commits without pinentry  |
-| fzf        |   ✅    | Module imported, chords disabled  |
-| worktrunk  |   ✅    | `git-wt` worktree management      |
-| PSReadLine |   ✅    | Emacs mode, history, prediction   |
-| thefuck    |   ✅    | Command correction                |
+| Feature | Status | Notes |
+| --- | :-: | --- |
+| Starship | ✅ | Full prompt with transient prompt |
+| zoxide | ✅ | `z` directory jumps |
+| mise | ✅ | Runtime version management |
+| aliases | ✅ | `ll`, `which`, etc. |
+| GPG cache | ✅ | Signing commits without pinentry |
+| fzf | ✅ | Module imported, chords disabled |
+| worktrunk | ✅ | `git-wt` worktree management |
+| PSReadLine | ✅ | Emacs mode, history, prediction |
+| thefuck | ✅ | Command correction |
 
 On Windows, the profile intentionally prefers `git-wt` for worktrunk
 so it does not confuse that binary with Windows Terminal's `wt.exe`.

--- a/docs/zellij-web-mobile.md
+++ b/docs/zellij-web-mobile.md
@@ -58,7 +58,7 @@ limitation on mobile.
 
 The `web_client.font` setting defaults to a Nerd Font fallback chain:
 
-```
+```css
 'HackGen Console NF', 'Hack Nerd Font', monospace
 ```
 


### PR DESCRIPTION
Closes #165.

## Summary
- `DavidAnson/markdownlint-cli2-action@v23`'s default `globs` is the non-recursive `*.{md,markdown}`, the workflow passes no `globs` input, and `.markdownlint-cli2.yaml` defined only a `CODE_OF_CONDUCT` ignore — so CI only ever linted 5 of 64 tracked markdown files. The green Linting badge was misleading.
- Added recursive `globs: ["**/*.{md,markdown}"]` to `.markdownlint-cli2.yaml` (config-file-based, so local runs and CI share it without touching the workflow), and extended `ignores` with `tests/bash/helpers/**` (git submodules — 652 pre-existing violations there must be ignored, not fixed) and `node_modules/**`.
- Fixed the 35 violations this surfaces in repo-native files:
  - **MD040** (fenced code blocks without a language): tagged ASCII-diagram blocks as `text` and a CSS font-family value as `css`.
  - **MD060** (table pipe style): reformatted the short reference tables in `docs/sshd-config-setup.md` to proper `aligned` style; reflowed the prose-heavy tables in `docs/secret-manager-setup.md` and the command table in `idd-overview.instructions.md` to `compact` style (single-space padding, no fixed-width alignment) — MD060's default `style` is `any`, and `compact` is far more maintainable for cells running to hundreds of characters, matching this repo's existing table `line-length` exception in `.markdownlint.yml` ("Allow limit breakthroughs ... due to folding difficulties"). `docs/vscode-terminal.md`'s emoji-status table also moved to `compact`, preserving its GFM center-alignment marker.
- Added `Fira` to the cspell word list — pre-existing in `docs/zellij-web-mobile.md`, surfaced only because this PR's MD040 fix touches that file and cspell's incremental scan checks whole changed files.

## Relationship to #170
Closing this resolves the residual acceptance-criteria gap left open on #170 ("docs: remove stale worktree claims from agent entry files") — its `npx markdownlint-cli2 "**/*.md"` criterion was blocked on this exact scope gap. Will re-verify and close #170 once this merges.

## Test plan
- [x] `npx markdownlint-cli2` (config-driven, recursive) → 61 files linted, 0 errors.
- [x] `npx cspell` on all 8 changed files → 0 issues.
- [x] `npx cspell "**/*.md"` full-repo sweep → 1 pre-existing, unrelated issue in `README.md` (`onlogon`), a file this PR does not touch — left alone.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 243/243 pass.
- [ ] CI lint job passes on this PR and its log shows ~61 files linted (visible evidence of the fixed scope).