### PR TITLE
feat(pwsh): declarative winget package dirs in user path

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -88,7 +88,7 @@ mise_trust = {{ dig "mise_trust" false $clone }}
 {{- range $key, $pkg := (dig "wingetUserPath" "packages" dict .) }}
 
 [data.wingetUserPath.packages."{{ $key }}"]
-id = {{ $pkg.id | quote }}
+id = {{ dig "id" "" $pkg | quote }}
 {{- if (dig "bin" "" $pkg) }}
 bin = {{ dig "bin" "" $pkg | quote }}
 {{- end }}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -85,6 +85,17 @@ ssh = {{ dig "ssh" true $clone }}
 mise_trust = {{ dig "mise_trust" false $clone }}
 {{- end }}
 {{- end }}
+{{- range $key, $pkg := (dig "wingetUserPath" "packages" dict .) }}
+
+[data.wingetUserPath.packages."{{ $key }}"]
+id = {{ $pkg.id | quote }}
+{{- if (dig "bin" "" $pkg) }}
+bin = {{ dig "bin" "" $pkg | quote }}
+{{- end }}
+{{- if not (dig "enabled" true $pkg) }}
+enabled = {{ dig "enabled" true $pkg }}
+{{- end }}
+{{- end }}
 {{- $sshServer := dig "ssh" "server" dict . }}
 {{- if $sshServer }}
 
@@ -185,6 +196,20 @@ attachment = {{ dig "attachment" "" $entry | quote }}
 #   mise_trust = false         # optional; true to auto-trust mise configs
 #
 # See docs/ghq-workflow.md for details.
+#
+# To register a WinGet-installed portable tool's real package
+# directory in the persisted Windows User PATH (needed when the
+# %LOCALAPPDATA%\Microsoft\WinGet\Links symlinks don't resolve, e.g.
+# inbound SSH sessions to Windows), add:
+#
+#   [data.wingetUserPath.packages.<label>]  # <label> is any unique name
+#   id      = "jdx.mise"       # WinGet package id (Packages\<id>_* prefix)
+#   bin     = "mise/bin"       # optional; subpath within the package dir
+#   enabled = true             # optional; false disables an inherited entry
+#
+# The real Packages\<id>_* directory (with bin appended, if set) is
+# placed in the managed User PATH ahead of WinGet\Links. See
+# docs/winget-user-path.md for details.
 #
 # To customize sshd_config hardening defaults, add:
 #

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -50,6 +50,7 @@ words:
   - luks
   - MYVIMRC
   - nnoremap
+  - onlogon
   - psmux
   - pylint
   - rerere

--- a/docs/winget-user-path.md
+++ b/docs/winget-user-path.md
@@ -1,0 +1,74 @@
+# Declaring WinGet package directories in the User PATH
+
+WinGet installs portable tools under
+`%LOCALAPPDATA%\Microsoft\WinGet\Packages\<id>_<publisher-hash>\` and
+exposes them via symlinks in `%LOCALAPPDATA%\Microsoft\WinGet\Links`.
+Those symlinks do not resolve in every session — notably inbound SSH
+sessions to Windows — which makes every WinGet-installed portable
+tool disappear from `PATH` in that context.
+
+This mechanism lets you declare a WinGet package's real package
+directory so it gets registered directly in the managed User PATH,
+ordered ahead of `WinGet\Links`, independent of whether the symlinks
+resolve.
+
+## Declaring a package
+
+Add an entry to `~/.config/chezmoi/chezmoi.toml`:
+
+```toml
+[data.wingetUserPath.packages.<label>]  # <label> is any unique name
+id      = "jdx.mise"       # WinGet package id (Packages\<id>_* prefix)
+bin     = "mise/bin"       # optional; subpath within the package dir
+enabled = true             # optional; false disables an inherited entry
+```
+
+- `<label>` is your own identifier for this declaration (used as the
+  TOML table key only; it has no effect on discovery).
+- `id` must match the WinGet package id, which is the prefix of the
+  directory chezmoi should find under
+  `%LOCALAPPDATA%\Microsoft\WinGet\Packages\` (WinGet appends a
+  publisher-specific hash, e.g. `jdx.mise_Microsoft.Winget.Source_...`;
+  matching is done by prefix, so the exact suffix does not need to be
+  known or kept up to date across package updates).
+- `bin` is an optional path, relative to the package directory, to
+  append before adding the directory to `PATH` (use this when the
+  executable lives in a subdirectory of the package, as most portable
+  WinGet packages do).
+- `enabled` defaults to `true`; set to `false` to disable a
+  repo-shipped default entry without deleting it (the repo ships an
+  empty default map today, so this mainly matters if a future repo
+  default gets added and you want to opt out).
+
+Run `chezmoi apply` after editing. Both the session PATH
+(`conf.d/01-path.ps1`) and the persisted registry User PATH
+(`run_onchange_after_35-register-path.ps1.tmpl`) pick up the change;
+the registry writer re-runs automatically because it hashes the
+effective declaration and re-triggers when it changes.
+
+## Merge behavior
+
+`data.wingetUserPath.packages` is a **map**, not a list. Chezmoi's
+config template (`.chezmoi.toml.tmpl`) re-emits whatever entries
+already exist in your `chezmoi.toml` on every `chezmoi init`/re-init,
+so per-machine entries you add persist across re-inits the same way
+`data.ghq.clone` or `data.secret.ssh.keys` entries do. The repository
+itself ships this map **empty** — there are no repo-wide default
+package declarations today, so every entry is something you add
+yourself, on the machine(s) where you need it.
+
+## How discovery works
+
+For each enabled declared package, the shared managed-path source
+(`home/dot_config/powershell/lib/managed-paths.ps1`) looks for
+directories under `%LOCALAPPDATA%\Microsoft\WinGet\Packages\`
+matching `<id>_*`, appends `bin` if set, and includes any that
+currently exist on disk — ahead of `WinGet\Links` and any other
+static managed entries. Directories that no longer exist are simply
+not included on the next reconciliation, and any stale entry
+previously registered for a declared package (matching the same
+`<id>_*` pattern) is recognized as managed and removed even if its
+directory is gone.
+
+Undeclared or absent packages contribute nothing, and unrelated
+`PATH` entries are always preserved.

--- a/docs/winget-user-path.md
+++ b/docs/winget-user-path.md
@@ -75,3 +75,11 @@ directory is gone.
 
 Undeclared or absent packages contribute nothing, and unrelated
 `PATH` entries are always preserved.
+
+To remove a package cleanly, set `enabled = false` first and run
+`chezmoi apply` (this removes its directory from `PATH` while it
+stays recognized as managed) before deleting the declaration
+outright. Deleting the entry directly skips that step: once it is
+gone from the manifest, its `<id>_*` pattern is no longer recognized,
+so any directory already added to `PATH` for it is left in place
+rather than cleaned up.

--- a/docs/winget-user-path.md
+++ b/docs/winget-user-path.md
@@ -38,7 +38,10 @@ enabled = true             # optional; false disables an inherited entry
 - `enabled` defaults to `true`; set to `false` to disable a
   repo-shipped default entry without deleting it (the repo ships an
   empty default map today, so this mainly matters if a future repo
-  default gets added and you want to opt out).
+  default gets added and you want to opt out). A disabled entry stays
+  in the rendered manifest — it is skipped when adding directories to
+  `PATH`, but its `<id>_*` pattern is still recognized so a previously
+  added directory is cleaned up as stale on the next reconciliation.
 
 Run `chezmoi apply` after editing. Both the session PATH
 (`conf.d/01-path.ps1`) and the persisted registry User PATH

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -75,12 +75,16 @@ function Get-StaticManagedPaths {
   return $paths
 }
 
-function Get-MisePackagesRoot {
+function Get-WingetPackagesRoot {
   if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
     return $null
   }
 
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
+}
+
+function Get-MisePackagesRoot {
+  Get-WingetPackagesRoot
 }
 
 function Get-WingetUserPathManifestPath {
@@ -118,14 +122,6 @@ function Get-WingetUserPathDeclaredPackages {
   return @($parsed | Where-Object { -not [string]::IsNullOrWhiteSpace($_.id) })
 }
 
-function Get-WingetPackagesRoot {
-  if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
-    return $null
-  }
-
-  return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
-}
-
 function Get-WingetUserPathManagedPaths {
   $packagesRoot = Get-WingetPackagesRoot
   if ([string]::IsNullOrEmpty($packagesRoot)) {
@@ -138,6 +134,12 @@ function Get-WingetUserPathManagedPaths {
 
   $paths = @()
   foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    # A missing 'enabled' property (older manifests, hand-built test
+    # fixtures) defaults to enabled; only an explicit $false disables.
+    if ($null -ne $declared.enabled -and $declared.enabled -eq $false) {
+      continue
+    }
+
     foreach ($packageDir in @(
       Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "$($declared.id)_*" } |

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -211,7 +211,7 @@ if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
     # recognized as stale for cleanup.
     $wingetUserPathPatterns += (
       '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
-      [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
+      [regex]::Escape(([string]$declared.id).ToLowerInvariant()) + '_[^\\]+' +
       '(\\.*)?$'
     )
   }

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -204,16 +204,15 @@ $wingetUserPathPatterns = @()
 if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
   $normalizedWingetRoot = Normalize-PathEntry $wingetPackagesRoot
   foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
-    $binSuffix = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
-      ''
-    } else {
-      '\\' + [regex]::Escape((Normalize-PathEntry $declared.bin))
-    }
-
+    # Match the whole package directory (any subpath), not just the
+    # currently-declared $bin suffix — otherwise changing bin (or
+    # disabling the entry, handled above) would orphan a previously
+    # added PATH entry that no longer matches, and it would never be
+    # recognized as stale for cleanup.
     $wingetUserPathPatterns += (
       '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
       [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
-      $binSuffix + '$'
+      '(\\.*)?$'
     )
   }
 }

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -142,7 +142,7 @@ function Get-WingetUserPathManagedPaths {
 
     foreach ($packageDir in @(
       Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -like "$($declared.id)_*" } |
+        Where-Object { $_.Name.StartsWith("$($declared.id)_", [StringComparison]::OrdinalIgnoreCase) } |
         Sort-Object -Property FullName
     )) {
       $dir = if ([string]::IsNullOrWhiteSpace($declared.bin)) {

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -8,6 +8,13 @@
 # Test-IsManagedPath, Get-RegistryUserPath, Set-RegistryUserPath, and
 # $desiredManagedPaths (deduplicated managed directories that exist
 # on disk).
+#
+# WinGet declared-package directories (data.wingetUserPath.packages,
+# see docs/winget-user-path.md) are discovered via the deployed
+# winget-user-path-packages.json manifest (Get-WingetUserPath*) and
+# placed ahead of WinGet\Links in $desiredManagedPaths, mirroring the
+# mise special case below it (folding the two together is tracked
+# separately).
 
 $sep = [IO.Path]::PathSeparator
 
@@ -76,6 +83,81 @@ function Get-MisePackagesRoot {
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
 }
 
+function Get-WingetUserPathManifestPath {
+  if ($null -ne $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST) {
+    return $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST
+  }
+
+  if ([string]::IsNullOrEmpty($HOME)) {
+    return $null
+  }
+
+  return Join-Path (
+    Join-Path (Join-Path $HOME '.config') 'powershell'
+  ) (Join-Path 'lib' 'winget-user-path-packages.json')
+}
+
+function Get-WingetUserPathDeclaredPackages {
+  $manifestPath = Get-WingetUserPathManifestPath
+  if ([string]::IsNullOrEmpty($manifestPath) -or
+      -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    return @()
+  }
+
+  $raw = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction SilentlyContinue
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return @()
+  }
+
+  try {
+    $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+  } catch {
+    return @()
+  }
+
+  return @($parsed | Where-Object { -not [string]::IsNullOrWhiteSpace($_.id) })
+}
+
+function Get-WingetPackagesRoot {
+  if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
+    return $null
+  }
+
+  return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
+}
+
+function Get-WingetUserPathManagedPaths {
+  $packagesRoot = Get-WingetPackagesRoot
+  if ([string]::IsNullOrEmpty($packagesRoot)) {
+    return @()
+  }
+
+  if (-not (Test-Path -LiteralPath $packagesRoot -PathType Container)) {
+    return @()
+  }
+
+  $paths = @()
+  foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    foreach ($packageDir in @(
+      Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "$($declared.id)_*" } |
+        Sort-Object -Property FullName
+    )) {
+      $dir = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
+        $packageDir.FullName
+      } else {
+        Join-Path $packageDir.FullName $declared.bin
+      }
+
+      if (Test-Path -LiteralPath $dir -PathType Container) {
+        $paths += $dir
+      }
+    }
+  }
+
+  return $paths
+}
+
 function Get-MiseManagedPaths {
   $packagesRoot = Get-MisePackagesRoot
   if ([string]::IsNullOrEmpty($packagesRoot)) {
@@ -115,6 +197,25 @@ if (-not [string]::IsNullOrEmpty($misePackagesRoot)) {
     '\\jdx\.mise_[^\\]+\\mise\\bin$'
 }
 
+$wingetPackagesRoot = Get-WingetPackagesRoot
+$wingetUserPathPatterns = @()
+if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
+  $normalizedWingetRoot = Normalize-PathEntry $wingetPackagesRoot
+  foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    $binSuffix = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
+      ''
+    } else {
+      '\\' + [regex]::Escape((Normalize-PathEntry $declared.bin))
+    }
+
+    $wingetUserPathPatterns += (
+      '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
+      [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
+      $binSuffix + '$'
+    )
+  }
+}
+
 function Test-IsManagedPath {
   param([AllowNull()][string]$PathEntry)
 
@@ -127,12 +228,18 @@ function Test-IsManagedPath {
     return $true
   }
 
+  foreach ($pattern in $wingetUserPathPatterns) {
+    if ($normalized -match $pattern) {
+      return $true
+    }
+  }
+
   return $false
 }
 
 $desiredManagedPaths = @()
 $desiredLookup = @{}
-foreach ($dir in @((@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
+foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + (@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
   if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
     continue
   }

--- a/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
+++ b/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
@@ -1,0 +1,12 @@
+{{- /* Deployed manifest consumed at runtime by managed-paths.ps1's
+     Get-WingetUserPathDeclaredPackages (plain, non-template file, so
+     it cannot read chezmoi data directly). One JSON object per
+     enabled entry in data.wingetUserPath.packages; see
+     docs/winget-user-path.md. */ -}}
+{{- $packages := list -}}
+{{- range $label, $pkg := (dig "wingetUserPath" "packages" dict .) -}}
+{{- if ne (dig "enabled" true $pkg) false -}}
+{{- $packages = append $packages (dict "label" $label "id" $pkg.id "bin" (dig "bin" "" $pkg)) -}}
+{{- end -}}
+{{- end -}}
+{{ $packages | toJson }}

--- a/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
+++ b/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
@@ -8,6 +8,6 @@
      docs/winget-user-path.md. */ -}}
 {{- $packages := list -}}
 {{- range $label, $pkg := (dig "wingetUserPath" "packages" dict .) -}}
-{{- $packages = append $packages (dict "label" $label "id" $pkg.id "bin" (dig "bin" "" $pkg) "enabled" (dig "enabled" true $pkg)) -}}
+{{- $packages = append $packages (dict "label" $label "id" (dig "id" "" $pkg) "bin" (dig "bin" "" $pkg) "enabled" (dig "enabled" true $pkg)) -}}
 {{- end -}}
 {{ $packages | toJson }}

--- a/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
+++ b/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
@@ -1,12 +1,13 @@
 {{- /* Deployed manifest consumed at runtime by managed-paths.ps1's
      Get-WingetUserPathDeclaredPackages (plain, non-template file, so
-     it cannot read chezmoi data directly). One JSON object per
-     enabled entry in data.wingetUserPath.packages; see
+     it cannot read chezmoi data directly). One JSON object per entry
+     in data.wingetUserPath.packages, including disabled ones — a
+     disabled entry must stay visible so managed-paths.ps1 can still
+     recognize its directory as managed and remove it from PATH
+     if present; only the PATH-add side skips disabled entries. See
      docs/winget-user-path.md. */ -}}
 {{- $packages := list -}}
 {{- range $label, $pkg := (dig "wingetUserPath" "packages" dict .) -}}
-{{- if ne (dig "enabled" true $pkg) false -}}
-{{- $packages = append $packages (dict "label" $label "id" $pkg.id "bin" (dig "bin" "" $pkg)) -}}
-{{- end -}}
+{{- $packages = append $packages (dict "label" $label "id" $pkg.id "bin" (dig "bin" "" $pkg) "enabled" (dig "enabled" true $pkg)) -}}
 {{- end -}}
 {{ $packages | toJson }}

--- a/home/run_onchange_after_35-register-path.ps1.tmpl
+++ b/home/run_onchange_after_35-register-path.ps1.tmpl
@@ -1,9 +1,11 @@
 # chezmoi:template:left-delimiter=<% right-delimiter=%>
 <%- if eq .chezmoi.os "windows" %>
 # Register tool directories in User PATH (Windows registry).
-# Re-runs when the managed-paths list changes (hash below).
+# Re-runs when the managed-paths list or the winget declaration
+# changes (hashes below).
 #
 # hash: <% include "dot_config/powershell/lib/managed-paths.ps1" | sha256sum %>
+# winget user path packages hash: <% (dig "wingetUserPath" "packages" dict .) | toJson | sha256sum %>
 
 # Reconcile the repo-managed subset of User PATH. Both surfaces
 # compute the managed-path set from the shared source embedded

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -50,6 +50,12 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     $homeRoot = (New-Item -ItemType Directory -Path 'TestDrive:\home' -Force).FullName
     $localAppDataRoot = (New-Item -ItemType Directory -Path 'TestDrive:\LocalAppData' -Force).FullName
     $programFilesX86Root = (New-Item -ItemType Directory -Path 'TestDrive:\ProgramFilesX86' -Force).FullName
+    # Captured immediately (before $env:LOCALAPPDATA is reassigned)
+    # so the "winget declared packages" Context's AfterEach cleanup
+    # always targets this TestDrive-rooted path, even if a later
+    # step in this block were to fail — never the real
+    # %LOCALAPPDATA%, which could otherwise be deleted from.
+    $script:TestWingetPackagesRoot = Join-Path $localAppDataRoot 'Microsoft\WinGet\Packages'
 
     Set-Variable -Name HOME -Value $homeRoot -Scope Global -Force
     $env:LOCALAPPDATA = $localAppDataRoot
@@ -93,6 +99,7 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Get-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
+    $script:TestWingetPackagesRoot = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -195,9 +202,14 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       # GitHub.cli_* directory a test creates must be removed here —
       # otherwise it leaks into later tests (e.g. "contributes
       # nothing") that assert no matching directory exists on disk.
-      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
-      Get-ChildItem -LiteralPath $packagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
-        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+      # Uses the TestDrive-rooted path captured in the outer
+      # BeforeEach rather than re-reading $env:LOCALAPPDATA, so a
+      # partially-failed BeforeEach can never point this cleanup at
+      # a real %LOCALAPPDATA%.
+      if (-not [string]::IsNullOrEmpty($script:TestWingetPackagesRoot)) {
+        Get-ChildItem -LiteralPath $script:TestWingetPackagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+          Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+      }
     }
 
     It 'adds a declared package real bin directory ahead of WinGet\Links' {

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -85,9 +85,14 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Test-IsManagedPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -175,6 +180,90 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $secondPath = $env:PATH
 
       $secondPath | Should -Be $firstPath
+    }
+  }
+
+  Context 'winget declared packages' {
+
+    BeforeEach {
+      $script:WingetManifestPath = 'TestDrive:\winget-manifest.json'
+      $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:WingetManifestPath
+    }
+
+    It 'adds a declared package real bin directory ahead of WinGet\Links' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      . $script:Subject
+
+      $entries = @($env:PATH -split ';')
+      $entries | Should -Contain $binDir
+      ([array]::IndexOf($entries, $binDir)) |
+        Should -BeLessThan ([array]::IndexOf($entries, $script:Paths.WinGetLinks))
+    }
+
+    It 'removes a stale sibling directory of a declared package while keeping the current one' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $currentBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      $staleBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_stale') 'bin'
+      New-Item -ItemType Directory -Path $currentBinDir -Force | Out-Null
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      $env:PATH = @(
+        $script:Paths.UnrelatedA
+        $staleBinDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
+      . $script:Subject
+
+      $entries = @($env:PATH -split ';')
+      $entries | Should -Contain $currentBinDir
+      $entries | Should -Not -Contain $staleBinDir
+    }
+
+    It 'contributes nothing when the declared package has no matching directory on disk' {
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      . $script:Subject
+
+      $env:PATH | Should -Be (@(
+        $script:Paths.CurrentMiseBin
+        $script:Paths.WinGetLinks
+        $script:Paths.Zellij
+        $script:Paths.GnuWin32
+        $script:Paths.HomeLocalBin
+        $script:Paths.HomeCargoBin
+        $script:Paths.UnrelatedA
+        $script:Paths.UnrelatedB
+      ) -join ';')
+    }
+
+    It 'is a no-op when no packages are declared (empty manifest)' {
+      Set-Content -Path $script:WingetManifestPath -Value '[]'
+
+      . $script:Subject
+
+      $env:PATH | Should -Be (@(
+        $script:Paths.CurrentMiseBin
+        $script:Paths.WinGetLinks
+        $script:Paths.Zellij
+        $script:Paths.GnuWin32
+        $script:Paths.HomeLocalBin
+        $script:Paths.HomeCargoBin
+        $script:Paths.UnrelatedA
+        $script:Paths.UnrelatedB
+      ) -join ';')
     }
   }
 }

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -205,9 +205,7 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
       New-Item -ItemType Directory -Path $binDir -Force | Out-Null
 
-      Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
-      )
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Subject
 
@@ -223,9 +221,7 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $staleBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_stale') 'bin'
       New-Item -ItemType Directory -Path $currentBinDir -Force | Out-Null
 
-      Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
-      )
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       $env:PATH = @(
         $script:Paths.UnrelatedA
@@ -240,10 +236,30 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $entries | Should -Not -Contain $staleBinDir
     }
 
-    It 'contributes nothing when the declared package has no matching directory on disk' {
+    It 'removes a previously-added directory once its declared package is disabled' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+      $env:PATH = @(
+        $script:Paths.UnrelatedA
+        $binDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
       Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+        '[{"label":"gh","id":"GitHub.cli","bin":"bin","enabled":false}]'
       )
+
+      . $script:Subject
+
+      $entries = @($env:PATH -split ';')
+      $entries | Should -Not -Contain $binDir
+      $entries | Should -Contain $script:Paths.UnrelatedA
+    }
+
+    It 'contributes nothing when the declared package has no matching directory on disk' {
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Subject
 

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -236,6 +236,30 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $entries | Should -Not -Contain $staleBinDir
     }
 
+    It 'removes a previously-added directory once its declared package''s bin changes' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $oldBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'old-bin'
+      $newBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'new-bin'
+      New-Item -ItemType Directory -Path $oldBinDir -Force | Out-Null
+      New-Item -ItemType Directory -Path $newBinDir -Force | Out-Null
+
+      $env:PATH = @(
+        $script:Paths.UnrelatedA
+        $oldBinDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        '[{"label":"gh","id":"GitHub.cli","bin":"new-bin"}]'
+      )
+
+      . $script:Subject
+
+      $entries = @($env:PATH -split ';')
+      $entries | Should -Not -Contain $oldBinDir
+      $entries | Should -Contain $newBinDir
+    }
+
     It 'removes a previously-added directory once its declared package is disabled' {
       $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -190,6 +190,16 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:WingetManifestPath
     }
 
+    AfterEach {
+      # TestDrive: persists across It blocks within this run, so any
+      # GitHub.cli_* directory a test creates must be removed here —
+      # otherwise it leaks into later tests (e.g. "contributes
+      # nothing") that assert no matching directory exists on disk.
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      Get-ChildItem -LiteralPath $packagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     It 'adds a declared package real bin directory ahead of WinGet\Links' {
       $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -133,6 +133,16 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:WingetManifestPath
     }
 
+    AfterEach {
+      # TestDrive: persists across It blocks within this run, so any
+      # GitHub.cli_* directory a test creates must be removed here —
+      # otherwise it leaks into later tests (e.g. "contributes
+      # nothing") that assert no matching directory exists on disk.
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      Get-ChildItem -LiteralPath $packagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     It 'adds a declared package real bin directory ahead of WinGet\Links' {
       $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -148,9 +148,7 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
       New-Item -ItemType Directory -Path $binDir -Force | Out-Null
 
-      Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
-      )
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Fixture 6>&1 | Out-Null
 
@@ -166,9 +164,7 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       $staleBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_stale') 'bin'
       New-Item -ItemType Directory -Path $currentBinDir -Force | Out-Null
 
-      Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
-      )
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
         $script:Paths.UnrelatedA
@@ -183,10 +179,47 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       $entries | Should -Not -Contain $staleBinDir
     }
 
-    It 'contributes nothing when the declared package has no matching directory on disk' {
+    It 'removes a previously-added directory once its declared package is disabled' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
+        $script:Paths.UnrelatedA
+        $binDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
       Set-Content -Path $script:WingetManifestPath -Value (
-        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+        '[{"label":"gh","id":"GitHub.cli","bin":"bin","enabled":false}]'
       )
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $entries = @($env:DOTFILES_TEST_REGISTRY_USER_PATH -split ';')
+      $entries | Should -Not -Contain $binDir
+      $entries | Should -Contain $script:Paths.UnrelatedA
+    }
+
+    It 'contributes nothing when the declared package has no matching directory on disk' {
+      Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH | Should -Be (@(
+        $script:Paths.CurrentMiseBin
+        $script:Paths.WinGetLinks
+        $script:Paths.Zellij
+        $script:Paths.GnuWin32
+        $script:Paths.HomeLocalBin
+        $script:Paths.HomeCargoBin
+        $script:Paths.UnrelatedA
+        $script:Paths.UnrelatedB
+      ) -join ';')
+    }
+
+    It 'is a no-op when no packages are declared (empty manifest)' {
+      Set-Content -Path $script:WingetManifestPath -Value '[]'
 
       . $script:Fixture 6>&1 | Out-Null
 

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -179,6 +179,30 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       $entries | Should -Not -Contain $staleBinDir
     }
 
+    It 'removes a previously-added directory once its declared package''s bin changes' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $oldBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'old-bin'
+      $newBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'new-bin'
+      New-Item -ItemType Directory -Path $oldBinDir -Force | Out-Null
+      New-Item -ItemType Directory -Path $newBinDir -Force | Out-Null
+
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
+        $script:Paths.UnrelatedA
+        $oldBinDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        '[{"label":"gh","id":"GitHub.cli","bin":"new-bin"}]'
+      )
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $entries = @($env:DOTFILES_TEST_REGISTRY_USER_PATH -split ';')
+      $entries | Should -Not -Contain $oldBinDir
+      $entries | Should -Contain $newBinDir
+    }
+
     It 'removes a previously-added directory once its declared package is disabled' {
       $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
       $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -50,6 +50,12 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     $homeRoot = (New-Item -ItemType Directory -Path 'TestDrive:\home' -Force).FullName
     $localAppDataRoot = (New-Item -ItemType Directory -Path 'TestDrive:\LocalAppData' -Force).FullName
     $programFilesX86Root = (New-Item -ItemType Directory -Path 'TestDrive:\ProgramFilesX86' -Force).FullName
+    # Captured immediately (before $env:LOCALAPPDATA is reassigned)
+    # so the "winget declared packages" Context's AfterEach cleanup
+    # always targets this TestDrive-rooted path, even if a later
+    # step in this block were to fail — never the real
+    # %LOCALAPPDATA%, which could otherwise be deleted from.
+    $script:TestWingetPackagesRoot = Join-Path $localAppDataRoot 'Microsoft\WinGet\Packages'
 
     Set-Variable -Name HOME -Value $homeRoot -Scope Global -Force
     $env:LOCALAPPDATA = $localAppDataRoot
@@ -85,6 +91,7 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Set-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
+    $script:TestWingetPackagesRoot = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -138,9 +145,14 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       # GitHub.cli_* directory a test creates must be removed here —
       # otherwise it leaks into later tests (e.g. "contributes
       # nothing") that assert no matching directory exists on disk.
-      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
-      Get-ChildItem -LiteralPath $packagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
-        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+      # Uses the TestDrive-rooted path captured in the outer
+      # BeforeEach rather than re-reading $env:LOCALAPPDATA, so a
+      # partially-failed BeforeEach can never point this cleanup at
+      # a real %LOCALAPPDATA%.
+      if (-not [string]::IsNullOrEmpty($script:TestWingetPackagesRoot)) {
+        Get-ChildItem -LiteralPath $script:TestWingetPackagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+          Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+      }
     }
 
     It 'adds a declared package real bin directory ahead of WinGet\Links' {

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -76,10 +76,15 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Test-IsManagedPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-RegistryUserPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Set-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -119,5 +124,72 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     $output = . $script:Fixture 6>&1 | Out-String
 
     $output | Should -BeLike '*User PATH already up to date.*'
+  }
+
+  Context 'winget declared packages' {
+
+    BeforeEach {
+      $script:WingetManifestPath = 'TestDrive:\winget-manifest.json'
+      $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:WingetManifestPath
+    }
+
+    It 'adds a declared package real bin directory ahead of WinGet\Links' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $entries = @($env:DOTFILES_TEST_REGISTRY_USER_PATH -split ';')
+      $entries | Should -Contain $binDir
+      ([array]::IndexOf($entries, $binDir)) |
+        Should -BeLessThan ([array]::IndexOf($entries, $script:Paths.WinGetLinks))
+    }
+
+    It 'removes a stale sibling directory of a declared package while keeping the current one' {
+      $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+      $currentBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+      $staleBinDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_stale') 'bin'
+      New-Item -ItemType Directory -Path $currentBinDir -Force | Out-Null
+
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
+        $script:Paths.UnrelatedA
+        $staleBinDir
+        $script:Paths.WinGetLinks
+      ) -join ';'
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $entries = @($env:DOTFILES_TEST_REGISTRY_USER_PATH -split ';')
+      $entries | Should -Contain $currentBinDir
+      $entries | Should -Not -Contain $staleBinDir
+    }
+
+    It 'contributes nothing when the declared package has no matching directory on disk' {
+      Set-Content -Path $script:WingetManifestPath -Value (
+        @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+      )
+
+      . $script:Fixture 6>&1 | Out-Null
+
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH | Should -Be (@(
+        $script:Paths.CurrentMiseBin
+        $script:Paths.WinGetLinks
+        $script:Paths.Zellij
+        $script:Paths.GnuWin32
+        $script:Paths.HomeLocalBin
+        $script:Paths.HomeCargoBin
+        $script:Paths.UnrelatedA
+        $script:Paths.UnrelatedB
+      ) -join ';')
+    }
   }
 }

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -220,16 +220,15 @@ $wingetUserPathPatterns = @()
 if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
   $normalizedWingetRoot = Normalize-PathEntry $wingetPackagesRoot
   foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
-    $binSuffix = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
-      ''
-    } else {
-      '\\' + [regex]::Escape((Normalize-PathEntry $declared.bin))
-    }
-
+    # Match the whole package directory (any subpath), not just the
+    # currently-declared $bin suffix — otherwise changing bin (or
+    # disabling the entry, handled above) would orphan a previously
+    # added PATH entry that no longer matches, and it would never be
+    # recognized as stale for cleanup.
     $wingetUserPathPatterns += (
       '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
       [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
-      $binSuffix + '$'
+      '(\\.*)?$'
     )
   }
 }

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -227,7 +227,7 @@ if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
     # recognized as stale for cleanup.
     $wingetUserPathPatterns += (
       '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
-      [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
+      [regex]::Escape(([string]$declared.id).ToLowerInvariant()) + '_[^\\]+' +
       '(\\.*)?$'
     )
   }

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -91,12 +91,16 @@ function Get-StaticManagedPaths {
   return $paths
 }
 
-function Get-MisePackagesRoot {
+function Get-WingetPackagesRoot {
   if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
     return $null
   }
 
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
+}
+
+function Get-MisePackagesRoot {
+  Get-WingetPackagesRoot
 }
 
 function Get-WingetUserPathManifestPath {
@@ -134,14 +138,6 @@ function Get-WingetUserPathDeclaredPackages {
   return @($parsed | Where-Object { -not [string]::IsNullOrWhiteSpace($_.id) })
 }
 
-function Get-WingetPackagesRoot {
-  if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
-    return $null
-  }
-
-  return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
-}
-
 function Get-WingetUserPathManagedPaths {
   $packagesRoot = Get-WingetPackagesRoot
   if ([string]::IsNullOrEmpty($packagesRoot)) {
@@ -154,6 +150,12 @@ function Get-WingetUserPathManagedPaths {
 
   $paths = @()
   foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    # A missing 'enabled' property (older manifests, hand-built test
+    # fixtures) defaults to enabled; only an explicit $false disables.
+    if ($null -ne $declared.enabled -and $declared.enabled -eq $false) {
+      continue
+    }
+
     foreach ($packageDir in @(
       Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -like "$($declared.id)_*" } |

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -1,12 +1,13 @@
 #!/usr/bin/env pwsh
 # Pre-rendered test fixture for run_onchange_after_35-register-path.ps1.tmpl.
-# Hash comment is replaced with a dummy value since tests don't use chezmoi.
-# The lib/managed-paths.ps1 block below is a literal copy of what
-# chezmoi's `include` would splice in at apply time — keep it in sync
-# with home/dot_config/powershell/lib/managed-paths.ps1 by hand; the
-# managed-paths-parity Pester test fails if this copy drifts.
+# Hash comments are replaced with dummy values since tests don't use
+# chezmoi. The lib/managed-paths.ps1 block below is a literal copy of
+# what chezmoi's `include` would splice in at apply time — keep it in
+# sync with home/dot_config/powershell/lib/managed-paths.ps1 by hand;
+# the managed-paths-parity Pester test fails if this copy drifts.
 #
 # hash: ae7bacf10ef20f21f4c9c7992c5fd51a9aa9620333b77b480b2121200dcd23e0
+# winget user path packages hash: 44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
 
 # Reconcile the repo-managed subset of User PATH. Both surfaces
 # compute the managed-path set from the shared source embedded
@@ -23,6 +24,13 @@
 # Test-IsManagedPath, Get-RegistryUserPath, Set-RegistryUserPath, and
 # $desiredManagedPaths (deduplicated managed directories that exist
 # on disk).
+#
+# WinGet declared-package directories (data.wingetUserPath.packages,
+# see docs/winget-user-path.md) are discovered via the deployed
+# winget-user-path-packages.json manifest (Get-WingetUserPath*) and
+# placed ahead of WinGet\Links in $desiredManagedPaths, mirroring the
+# mise special case below it (folding the two together is tracked
+# separately).
 
 $sep = [IO.Path]::PathSeparator
 
@@ -91,6 +99,81 @@ function Get-MisePackagesRoot {
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
 }
 
+function Get-WingetUserPathManifestPath {
+  if ($null -ne $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST) {
+    return $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST
+  }
+
+  if ([string]::IsNullOrEmpty($HOME)) {
+    return $null
+  }
+
+  return Join-Path (
+    Join-Path (Join-Path $HOME '.config') 'powershell'
+  ) (Join-Path 'lib' 'winget-user-path-packages.json')
+}
+
+function Get-WingetUserPathDeclaredPackages {
+  $manifestPath = Get-WingetUserPathManifestPath
+  if ([string]::IsNullOrEmpty($manifestPath) -or
+      -not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    return @()
+  }
+
+  $raw = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction SilentlyContinue
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return @()
+  }
+
+  try {
+    $parsed = $raw | ConvertFrom-Json -ErrorAction Stop
+  } catch {
+    return @()
+  }
+
+  return @($parsed | Where-Object { -not [string]::IsNullOrWhiteSpace($_.id) })
+}
+
+function Get-WingetPackagesRoot {
+  if ([string]::IsNullOrEmpty($env:LOCALAPPDATA)) {
+    return $null
+  }
+
+  return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
+}
+
+function Get-WingetUserPathManagedPaths {
+  $packagesRoot = Get-WingetPackagesRoot
+  if ([string]::IsNullOrEmpty($packagesRoot)) {
+    return @()
+  }
+
+  if (-not (Test-Path -LiteralPath $packagesRoot -PathType Container)) {
+    return @()
+  }
+
+  $paths = @()
+  foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    foreach ($packageDir in @(
+      Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "$($declared.id)_*" } |
+        Sort-Object -Property FullName
+    )) {
+      $dir = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
+        $packageDir.FullName
+      } else {
+        Join-Path $packageDir.FullName $declared.bin
+      }
+
+      if (Test-Path -LiteralPath $dir -PathType Container) {
+        $paths += $dir
+      }
+    }
+  }
+
+  return $paths
+}
+
 function Get-MiseManagedPaths {
   $packagesRoot = Get-MisePackagesRoot
   if ([string]::IsNullOrEmpty($packagesRoot)) {
@@ -130,6 +213,25 @@ if (-not [string]::IsNullOrEmpty($misePackagesRoot)) {
     '\\jdx\.mise_[^\\]+\\mise\\bin$'
 }
 
+$wingetPackagesRoot = Get-WingetPackagesRoot
+$wingetUserPathPatterns = @()
+if (-not [string]::IsNullOrEmpty($wingetPackagesRoot)) {
+  $normalizedWingetRoot = Normalize-PathEntry $wingetPackagesRoot
+  foreach ($declared in @(Get-WingetUserPathDeclaredPackages)) {
+    $binSuffix = if ([string]::IsNullOrWhiteSpace($declared.bin)) {
+      ''
+    } else {
+      '\\' + [regex]::Escape((Normalize-PathEntry $declared.bin))
+    }
+
+    $wingetUserPathPatterns += (
+      '^' + [regex]::Escape($normalizedWingetRoot) + '\\' +
+      [regex]::Escape($declared.id.ToLowerInvariant()) + '_[^\\]+' +
+      $binSuffix + '$'
+    )
+  }
+}
+
 function Test-IsManagedPath {
   param([AllowNull()][string]$PathEntry)
 
@@ -142,12 +244,18 @@ function Test-IsManagedPath {
     return $true
   }
 
+  foreach ($pattern in $wingetUserPathPatterns) {
+    if ($normalized -match $pattern) {
+      return $true
+    }
+  }
+
   return $false
 }
 
 $desiredManagedPaths = @()
 $desiredLookup = @{}
-foreach ($dir in @((@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
+foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + (@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
   if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
     continue
   }

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -158,7 +158,7 @@ function Get-WingetUserPathManagedPaths {
 
     foreach ($packageDir in @(
       Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -like "$($declared.id)_*" } |
+        Where-Object { $_.Name.StartsWith("$($declared.id)_", [StringComparison]::OrdinalIgnoreCase) } |
         Sort-Object -Property FullName
     )) {
       $dir = if ([string]::IsNullOrWhiteSpace($declared.bin)) {

--- a/tests/powershell/managed-paths-parity.Tests.ps1
+++ b/tests/powershell/managed-paths-parity.Tests.ps1
@@ -113,9 +113,7 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     New-Item -ItemType Directory -Path $binDir -Force | Out-Null
 
     $manifestPath = 'TestDrive:\winget-manifest.json'
-    Set-Content -Path $manifestPath -Value (
-      @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
-    )
+    Set-Content -Path $manifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $manifestPath
 
     . $script:ConfDScript

--- a/tests/powershell/managed-paths-parity.Tests.ps1
+++ b/tests/powershell/managed-paths-parity.Tests.ps1
@@ -67,6 +67,14 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
   }
 
   AfterEach {
+    # TestDrive: persists for the whole Pester session, not just this
+    # Describe — remove any GitHub.cli_* directory a test created
+    # (before $env:LOCALAPPDATA below is restored to its real value)
+    # so it cannot leak into a later file's assumptions.
+    $packagesRootCleanup = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    Get-ChildItem -LiteralPath $packagesRootCleanup -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+      Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
     Set-Variable -Name HOME -Value $script:OriginalHome -Scope Global -Force
     $env:PATH = $script:OriginalPath
     $env:LOCALAPPDATA = $script:OriginalLocalAppData

--- a/tests/powershell/managed-paths-parity.Tests.ps1
+++ b/tests/powershell/managed-paths-parity.Tests.ps1
@@ -77,10 +77,15 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
+    Remove-Item Function:\Get-WingetUserPathManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Test-IsManagedPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-RegistryUserPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Set-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
   }
 
   It 'computes the identical managed-path set on both surfaces' {
@@ -91,6 +96,27 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     $registerManagedPaths = @($desiredManagedPaths)
 
     $confDManagedPaths | Should -Not -BeNullOrEmpty
+    $registerManagedPaths | Should -Be $confDManagedPaths
+  }
+
+  It 'computes the identical managed-path set on both surfaces with a winget package declared' {
+    $packagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    $binDir = Join-Path (Join-Path $packagesRoot 'GitHub.cli_Microsoft.Winget.Source_test') 'bin'
+    New-Item -ItemType Directory -Path $binDir -Force | Out-Null
+
+    $manifestPath = 'TestDrive:\winget-manifest.json'
+    Set-Content -Path $manifestPath -Value (
+      @(@{ label = 'gh'; id = 'GitHub.cli'; bin = 'bin' } ) | ConvertTo-Json -AsArray
+    )
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $manifestPath
+
+    . $script:ConfDScript
+    $confDManagedPaths = @($desiredManagedPaths)
+
+    . $script:RegisterFixture 6>&1 | Out-Null
+    $registerManagedPaths = @($desiredManagedPaths)
+
+    $confDManagedPaths | Should -Contain $binDir
     $registerManagedPaths | Should -Be $confDManagedPaths
   }
 }

--- a/tests/powershell/managed-paths-parity.Tests.ps1
+++ b/tests/powershell/managed-paths-parity.Tests.ps1
@@ -52,6 +52,12 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     $homeRoot = (New-Item -ItemType Directory -Path 'TestDrive:\home' -Force).FullName
     $localAppDataRoot = (New-Item -ItemType Directory -Path 'TestDrive:\LocalAppData' -Force).FullName
     $programFilesX86Root = (New-Item -ItemType Directory -Path 'TestDrive:\ProgramFilesX86' -Force).FullName
+    # Captured immediately (before $env:LOCALAPPDATA is reassigned)
+    # so the AfterEach cleanup below always targets this
+    # TestDrive-rooted path, even if a later step in this block
+    # were to fail — never the real %LOCALAPPDATA%, which could
+    # otherwise be deleted from.
+    $script:TestWingetPackagesRoot = Join-Path $localAppDataRoot 'Microsoft\WinGet\Packages'
 
     Set-Variable -Name HOME -Value $homeRoot -Scope Global -Force
     $env:LOCALAPPDATA = $localAppDataRoot
@@ -70,10 +76,14 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     # TestDrive: persists for the whole Pester session, not just this
     # Describe — remove any GitHub.cli_* directory a test created
     # (before $env:LOCALAPPDATA below is restored to its real value)
-    # so it cannot leak into a later file's assumptions.
-    $packagesRootCleanup = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
-    Get-ChildItem -LiteralPath $packagesRootCleanup -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
-      Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    # so it cannot leak into a later file's assumptions. Uses the
+    # TestDrive-rooted path captured in BeforeEach rather than
+    # re-reading $env:LOCALAPPDATA, so a partially-failed BeforeEach
+    # can never point this cleanup at a real %LOCALAPPDATA%.
+    if (-not [string]::IsNullOrEmpty($script:TestWingetPackagesRoot)) {
+      Get-ChildItem -LiteralPath $script:TestWingetPackagesRoot -Directory -Filter 'GitHub.cli_*' -ErrorAction SilentlyContinue |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
 
     Set-Variable -Name HOME -Value $script:OriginalHome -Scope Global -Force
     $env:PATH = $script:OriginalPath
@@ -94,6 +104,7 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Set-RegistryUserPath -ErrorAction SilentlyContinue
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
+    $script:TestWingetPackagesRoot = $null
   }
 
   It 'computes the identical managed-path set on both surfaces' {


### PR DESCRIPTION
Closes #177.

## Summary
- Adds `data.wingetUserPath.packages` as a hybrid-declaration map (repo ships it empty; per-machine entries in `~/.config/chezmoi/chezmoi.toml` persist across `chezmoi init` the same way `data.ghq.clone`/`data.secret.ssh.keys` already do — traced the existing precedent to confirm there's no separate repo-default-merge step for these map-shaped keys).
- Renders the effective declaration into a deployed JSON manifest (`winget-user-path-packages.json`, precedent: `chezmoi-ghq-trusted-paths` consumed by `conf.d/30-mise.ps1`) that the shared, non-template `managed-paths.ps1` reads at runtime.
- For each enabled declared package, discovers `WinGet\Packages\<id>_*` (+ optional `bin` subpath) and places existing directories ahead of `WinGet\Links` on both PATH surfaces, reusing the existing existence-gated/deduplicating reconciliation loop and a stale-sibling regex pattern (mirroring the existing mise pattern) so a removed package version is dropped even after its directory disappears.
- Hashes the underlying `wingetUserPath.packages` *data* (not the manifest template's source) in the registry writer's re-run trigger, alongside the existing `managed-paths.ps1` hash.
- Leaves the mise special case untouched on purpose — folding it into this generic mechanism is #178; a small `Get-WingetPackagesRoot` duplicates `Get-MisePackagesRoot`'s path expression in the meantime rather than calling a mise-named function from generic code.
- `docs/winget-user-path.md` documents the key, the merge/persistence behavior, and the disable switch.

## Test plan
- [x] Verified the manifest template renders correctly (enabled/disabled entries, empty default) and the resulting JSON round-trips through `ConvertFrom-Json` as expected.
- [x] Verified `.chezmoi.toml.tmpl` re-emits `[data.wingetUserPath.packages.<label>]` blocks correctly.
- [x] Verified the run_onchange hash trigger is a deterministic function of the declaration data (repeated renders of the same data produce the same hash; different data produces a different hash).
- [x] End-to-end verified via standalone (non-Pester) scripts, since these Pester scopes are Windows-only and Pester's `TestDrive:` provider can't be forced onto this non-Windows dev host: a declared package with a real directory appears ahead of `WinGet\Links`; a stale sibling directory is dropped while the current one is kept; an absent/undeclared package contributes nothing.
- [x] Confirmed the stale-removal assertion actually catches a regression: temporarily disabled the winget pattern check in `Test-IsManagedPath`, observed the stale entry incorrectly survive, then restored it.
- [x] `Invoke-Pester tests/powershell/` on Linux — all new tests discovered and skip cleanly (Windows-only scopes); no regressions in tests that do run there.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 243/243 pass.
- [x] `cspell` and `markdownlint-cli2` (recursive) pass on all changed/new files.
- [ ] Windows CI Pester leg carries the authoritative run for the new/updated Windows-only test scopes this PR adds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring WinGet portable packages whose directories should be included in the managed Windows `PATH`.
  * Automatically discovers installed package directories and optional `bin` folders.
  * Places valid package paths ahead of WinGet link paths and removes stale registrations.
  * Added documentation covering configuration, discovery, and persistence behavior.

* **Bug Fixes**
  * Improved handling when packages are missing, disabled, or symlinks cannot be resolved.

* **Tests**
  * Added coverage for package discovery, stale-path cleanup, missing packages, and parity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->