### PR TITLE
refactor(pwsh): fold jdx.mise discovery into the winget declaration

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -85,7 +85,14 @@ ssh = {{ dig "ssh" true $clone }}
 mise_trust = {{ dig "mise_trust" false $clone }}
 {{- end }}
 {{- end }}
-{{- range $key, $pkg := (dig "wingetUserPath" "packages" dict .) }}
+{{- /* Repo-shipped defaults for data.wingetUserPath.packages, merged
+     under any user-declared entries of the same key (dst wins
+     per-field via mergo/sprig merge, so overriding or disabling
+     with enabled = false doesn't require restating id/bin).
+     Mirrored in winget-user-path-packages.json.tmpl — keep both in
+     sync. */ -}}
+{{- $wingetDefaultPackages := dict "mise" (dict "id" "jdx.mise" "bin" "mise/bin") -}}
+{{- range $key, $pkg := (merge (dig "wingetUserPath" "packages" dict .) $wingetDefaultPackages) }}
 
 [data.wingetUserPath.packages."{{ $key }}"]
 id = {{ dig "id" "" $pkg | quote }}

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -48,6 +48,7 @@ words:
   - kito
   - luac
   - luks
+  - mergo
   - MYVIMRC
   - nnoremap
   - onlogon

--- a/docs/winget-user-path.md
+++ b/docs/winget-user-path.md
@@ -36,12 +36,11 @@ enabled = true             # optional; false disables an inherited entry
   executable lives in a subdirectory of the package, as most portable
   WinGet packages do).
 - `enabled` defaults to `true`; set to `false` to disable a
-  repo-shipped default entry without deleting it (the repo ships an
-  empty default map today, so this mainly matters if a future repo
-  default gets added and you want to opt out). A disabled entry stays
-  in the rendered manifest — it is skipped when adding directories to
-  `PATH`, but its `<id>_*` pattern is still recognized so a previously
-  added directory is cleaned up as stale on the next reconciliation.
+  repo-shipped default entry (see below) without deleting it. A
+  disabled entry stays in the rendered manifest — it is skipped when
+  adding directories to `PATH`, but its `<id>_*` pattern is still
+  recognized so a previously added directory is cleaned up as stale
+  on the next reconciliation.
 
 Run `chezmoi apply` after editing. Both the session PATH
 (`conf.d/01-path.ps1`) and the persisted registry User PATH
@@ -55,10 +54,21 @@ effective declaration and re-triggers when it changes.
 config template (`.chezmoi.toml.tmpl`) re-emits whatever entries
 already exist in your `chezmoi.toml` on every `chezmoi init`/re-init,
 so per-machine entries you add persist across re-inits the same way
-`data.ghq.clone` or `data.secret.ssh.keys` entries do. The repository
-itself ships this map **empty** — there are no repo-wide default
-package declarations today, so every entry is something you add
-yourself, on the machine(s) where you need it.
+`data.ghq.clone` or `data.secret.ssh.keys` entries do.
+
+The repository ships one default entry, labeled `mise`
+(`id = "jdx.mise"`, `bin = "mise/bin"`), merged underneath whatever
+you declare: a field you set on the same label (e.g. `enabled` or a
+different `bin`) overrides the repo default field-by-field, so you
+never need to restate `id`/`bin` just to disable it or add other
+packages alongside it. A label you don't touch at all falls back to
+the shipped default in full.
+
+Both `.chezmoi.toml.tmpl` (which persists the effective declaration
+into your `chezmoi.toml` on `chezmoi init`/re-init) and
+`winget-user-path-packages.json.tmpl` (the runtime manifest) apply
+this same repo-default merge, so `chezmoi apply` alone — without a
+prior re-init — already reflects it.
 
 ## How discovery works
 

--- a/home/dot_config/powershell/lib/managed-paths.ps1
+++ b/home/dot_config/powershell/lib/managed-paths.ps1
@@ -12,9 +12,10 @@
 # WinGet declared-package directories (data.wingetUserPath.packages,
 # see docs/winget-user-path.md) are discovered via the deployed
 # winget-user-path-packages.json manifest (Get-WingetUserPath*) and
-# placed ahead of WinGet\Links in $desiredManagedPaths, mirroring the
-# mise special case below it (folding the two together is tracked
-# separately).
+# placed ahead of WinGet\Links in $desiredManagedPaths. The repo
+# ships one such declaration as a default (see
+# docs/winget-user-path.md) — there is no hardcoded special case for
+# any specific package here.
 
 $sep = [IO.Path]::PathSeparator
 
@@ -81,10 +82,6 @@ function Get-WingetPackagesRoot {
   }
 
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
-}
-
-function Get-MisePackagesRoot {
-  Get-WingetPackagesRoot
 }
 
 function Get-WingetUserPathManifestPath {
@@ -160,43 +157,10 @@ function Get-WingetUserPathManagedPaths {
   return $paths
 }
 
-function Get-MiseManagedPaths {
-  $packagesRoot = Get-MisePackagesRoot
-  if ([string]::IsNullOrEmpty($packagesRoot)) {
-    return @()
-  }
-
-  if (-not (Test-Path -LiteralPath $packagesRoot -PathType Container)) {
-    return @()
-  }
-
-  $paths = @()
-  foreach ($packageDir in @(
-    Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
-      Where-Object { $_.Name -like 'jdx.mise_*' } |
-      Sort-Object -Property FullName
-  )) {
-    $binDir = Join-Path (Join-Path $packageDir.FullName 'mise') 'bin'
-    if (Test-Path -LiteralPath $binDir -PathType Container) {
-      $paths += $binDir
-    }
-  }
-
-  return $paths
-}
-
 $staticManagedPaths = @(Get-StaticManagedPaths)
 $managedLookup = @{}
 foreach ($dir in $staticManagedPaths) {
   $managedLookup[(Normalize-PathEntry $dir)] = $true
-}
-
-$misePackagesRoot = Get-MisePackagesRoot
-$misePackagePattern = $null
-if (-not [string]::IsNullOrEmpty($misePackagesRoot)) {
-  $misePackagePattern = '^' +
-    [regex]::Escape((Normalize-PathEntry $misePackagesRoot)) +
-    '\\jdx\.mise_[^\\]+\\mise\\bin$'
 }
 
 $wingetPackagesRoot = Get-WingetPackagesRoot
@@ -225,10 +189,6 @@ function Test-IsManagedPath {
     return $true
   }
 
-  if ($null -ne $misePackagePattern -and $normalized -match $misePackagePattern) {
-    return $true
-  }
-
   foreach ($pattern in $wingetUserPathPatterns) {
     if ($normalized -match $pattern) {
       return $true
@@ -240,7 +200,7 @@ function Test-IsManagedPath {
 
 $desiredManagedPaths = @()
 $desiredLookup = @{}
-foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + (@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
+foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + $staticManagedPaths)) {
   if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
     continue
   }

--- a/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
+++ b/home/dot_config/powershell/lib/winget-user-path-packages.json.tmpl
@@ -1,13 +1,16 @@
 {{- /* Deployed manifest consumed at runtime by managed-paths.ps1's
      Get-WingetUserPathDeclaredPackages (plain, non-template file, so
      it cannot read chezmoi data directly). One JSON object per entry
-     in data.wingetUserPath.packages, including disabled ones — a
-     disabled entry must stay visible so managed-paths.ps1 can still
-     recognize its directory as managed and remove it from PATH
-     if present; only the PATH-add side skips disabled entries. See
+     in data.wingetUserPath.packages (merged with the repo-shipped
+     defaults below — mirrored in .chezmoi.toml.tmpl, keep both in
+     sync), including disabled ones — a disabled entry must stay
+     visible so managed-paths.ps1 can still recognize its directory
+     as managed and remove it from PATH if present; only the
+     PATH-add side skips disabled entries. See
      docs/winget-user-path.md. */ -}}
+{{- $wingetDefaultPackages := dict "mise" (dict "id" "jdx.mise" "bin" "mise/bin") -}}
 {{- $packages := list -}}
-{{- range $label, $pkg := (dig "wingetUserPath" "packages" dict .) -}}
+{{- range $label, $pkg := (merge (dig "wingetUserPath" "packages" dict .) $wingetDefaultPackages) -}}
 {{- $packages = append $packages (dict "label" $label "id" (dig "id" "" $pkg) "bin" (dig "bin" "" $pkg) "enabled" (dig "enabled" true $pkg)) -}}
 {{- end -}}
 {{ $packages | toJson }}

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -63,6 +63,15 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
 
     $script:Paths = New-ManagedPathLayout
 
+    # jdx.mise is now a plain declared package (a repo-shipped
+    # default, see docs/winget-user-path.md), not a hardcoded special
+    # case — declare it here so the existing mise PATH scenarios below
+    # keep exercising it through the generic mechanism. The "winget
+    # declared packages" Context overrides this with its own manifest.
+    $script:BaseWingetManifestPath = 'TestDrive:\winget-manifest-base.json'
+    Set-Content -Path $script:BaseWingetManifestPath -Value '[{"label":"mise","id":"jdx.mise","bin":"mise/bin"}]'
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:BaseWingetManifestPath
+
     # Disable registry sync by default so existing tests are not
     # affected by the real Windows User PATH.
     # Use ';' not '' — Windows deletes env vars set to empty string,
@@ -89,8 +98,6 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Split-PathEntries -ErrorAction SilentlyContinue
     Remove-Item Function:\Normalize-PathEntry -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
@@ -100,6 +107,7 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
     $script:TestWingetPackagesRoot = $null
+    $script:BaseWingetManifestPath = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -295,12 +303,14 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     }
 
     It 'contributes nothing when the declared package has no matching directory on disk' {
+      # This Context's manifest declares only "gh" (overriding the
+      # outer BeforeEach's mise-declaring manifest), so mise
+      # contributes nothing here either.
       Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Subject
 
       $env:PATH | Should -Be (@(
-        $script:Paths.CurrentMiseBin
         $script:Paths.WinGetLinks
         $script:Paths.Zellij
         $script:Paths.GnuWin32
@@ -317,7 +327,6 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
       . $script:Subject
 
       $env:PATH | Should -Be (@(
-        $script:Paths.CurrentMiseBin
         $script:Paths.WinGetLinks
         $script:Paths.Zellij
         $script:Paths.GnuWin32

--- a/tests/powershell/01-path.Tests.ps1
+++ b/tests/powershell/01-path.Tests.ps1
@@ -305,7 +305,18 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     It 'contributes nothing when the declared package has no matching directory on disk' {
       # This Context's manifest declares only "gh" (overriding the
       # outer BeforeEach's mise-declaring manifest), so mise
-      # contributes nothing here either.
+      # contributes nothing here either. Reset $env:PATH without the
+      # outer BeforeEach's StaleMiseBin seed: that value is a real
+      # resolved TestDrive path (New-Item's .FullName, not a literal
+      # "TestDrive:\..." string), so without a mise declaration in
+      # this manifest it would no longer be recognized as managed and
+      # would leak into the result as an unrelated leftover entry.
+      $env:PATH = @(
+        $script:Paths.UnrelatedA
+        $script:Paths.WinGetLinks
+        $script:Paths.UnrelatedB
+        $script:Paths.WinGetLinks
+      ) -join ';'
       Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Subject
@@ -322,6 +333,15 @@ Describe '01-path' -Skip:($IsWindows -eq $false) {
     }
 
     It 'is a no-op when no packages are declared (empty manifest)' {
+      # See the comment above: reset $env:PATH without the mise
+      # StaleMiseBin seed, since an empty manifest declares no mise
+      # entry to recognize it as managed.
+      $env:PATH = @(
+        $script:Paths.UnrelatedA
+        $script:Paths.WinGetLinks
+        $script:Paths.UnrelatedB
+        $script:Paths.WinGetLinks
+      ) -join ';'
       Set-Content -Path $script:WingetManifestPath -Value '[]'
 
       . $script:Subject

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -63,6 +63,15 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
 
     $script:Paths = New-ManagedPathLayout
 
+    # jdx.mise is now a plain declared package (a repo-shipped
+    # default, see docs/winget-user-path.md), not a hardcoded special
+    # case — declare it here so the existing mise PATH scenarios below
+    # keep exercising it through the generic mechanism. The "winget
+    # declared packages" Context overrides this with its own manifest.
+    $script:BaseWingetManifestPath = 'TestDrive:\winget-manifest-base.json'
+    Set-Content -Path $script:BaseWingetManifestPath -Value '[{"label":"mise","id":"jdx.mise","bin":"mise/bin"}]'
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:BaseWingetManifestPath
+
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
       $script:Paths.UnrelatedA
       $script:Paths.StaleMiseBin
@@ -80,8 +89,6 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Split-PathEntries -ErrorAction SilentlyContinue
     Remove-Item Function:\Normalize-PathEntry -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
@@ -92,6 +99,7 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
     $script:TestWingetPackagesRoot = $null
+    $script:BaseWingetManifestPath = $null
   }
 
   It 'reconciles managed entries and removes stale winget package paths' {
@@ -238,12 +246,14 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     }
 
     It 'contributes nothing when the declared package has no matching directory on disk' {
+      # This Context's manifest declares only "gh" (overriding the
+      # outer BeforeEach's mise-declaring manifest), so mise
+      # contributes nothing here either.
       Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Fixture 6>&1 | Out-Null
 
       $env:DOTFILES_TEST_REGISTRY_USER_PATH | Should -Be (@(
-        $script:Paths.CurrentMiseBin
         $script:Paths.WinGetLinks
         $script:Paths.Zellij
         $script:Paths.GnuWin32
@@ -260,7 +270,6 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
       . $script:Fixture 6>&1 | Out-Null
 
       $env:DOTFILES_TEST_REGISTRY_USER_PATH | Should -Be (@(
-        $script:Paths.CurrentMiseBin
         $script:Paths.WinGetLinks
         $script:Paths.Zellij
         $script:Paths.GnuWin32

--- a/tests/powershell/35-register-path.Tests.ps1
+++ b/tests/powershell/35-register-path.Tests.ps1
@@ -248,7 +248,19 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     It 'contributes nothing when the declared package has no matching directory on disk' {
       # This Context's manifest declares only "gh" (overriding the
       # outer BeforeEach's mise-declaring manifest), so mise
-      # contributes nothing here either.
+      # contributes nothing here either. Reset the registry seed
+      # without the outer BeforeEach's StaleMiseBin entry: that value
+      # is a real resolved TestDrive path (New-Item's .FullName, not
+      # a literal "TestDrive:\..." string), so without a mise
+      # declaration in this manifest it would no longer be
+      # recognized as managed and would leak into the result as an
+      # unrelated leftover entry.
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
+        $script:Paths.UnrelatedA
+        $script:Paths.WinGetLinks
+        $script:Paths.UnrelatedB
+        $script:Paths.WinGetLinks
+      ) -join ';'
       Set-Content -Path $script:WingetManifestPath -Value '[{"label":"gh","id":"GitHub.cli","bin":"bin"}]'
 
       . $script:Fixture 6>&1 | Out-Null
@@ -265,6 +277,15 @@ Describe '35-register-path' -Skip:($IsWindows -eq $false) {
     }
 
     It 'is a no-op when no packages are declared (empty manifest)' {
+      # See the comment above: reset the registry seed without the
+      # mise StaleMiseBin entry, since an empty manifest declares no
+      # mise entry to recognize it as managed.
+      $env:DOTFILES_TEST_REGISTRY_USER_PATH = @(
+        $script:Paths.UnrelatedA
+        $script:Paths.WinGetLinks
+        $script:Paths.UnrelatedB
+        $script:Paths.WinGetLinks
+      ) -join ';'
       Set-Content -Path $script:WingetManifestPath -Value '[]'
 
       . $script:Fixture 6>&1 | Out-Null

--- a/tests/powershell/fixtures/35-register-path.ps1
+++ b/tests/powershell/fixtures/35-register-path.ps1
@@ -28,9 +28,10 @@
 # WinGet declared-package directories (data.wingetUserPath.packages,
 # see docs/winget-user-path.md) are discovered via the deployed
 # winget-user-path-packages.json manifest (Get-WingetUserPath*) and
-# placed ahead of WinGet\Links in $desiredManagedPaths, mirroring the
-# mise special case below it (folding the two together is tracked
-# separately).
+# placed ahead of WinGet\Links in $desiredManagedPaths. The repo
+# ships one such declaration as a default (see
+# docs/winget-user-path.md) — there is no hardcoded special case for
+# any specific package here.
 
 $sep = [IO.Path]::PathSeparator
 
@@ -97,10 +98,6 @@ function Get-WingetPackagesRoot {
   }
 
   return Join-Path (Join-Path (Join-Path $env:LOCALAPPDATA 'Microsoft') 'WinGet') 'Packages'
-}
-
-function Get-MisePackagesRoot {
-  Get-WingetPackagesRoot
 }
 
 function Get-WingetUserPathManifestPath {
@@ -176,43 +173,10 @@ function Get-WingetUserPathManagedPaths {
   return $paths
 }
 
-function Get-MiseManagedPaths {
-  $packagesRoot = Get-MisePackagesRoot
-  if ([string]::IsNullOrEmpty($packagesRoot)) {
-    return @()
-  }
-
-  if (-not (Test-Path -LiteralPath $packagesRoot -PathType Container)) {
-    return @()
-  }
-
-  $paths = @()
-  foreach ($packageDir in @(
-    Get-ChildItem -LiteralPath $packagesRoot -Directory -ErrorAction SilentlyContinue |
-      Where-Object { $_.Name -like 'jdx.mise_*' } |
-      Sort-Object -Property FullName
-  )) {
-    $binDir = Join-Path (Join-Path $packageDir.FullName 'mise') 'bin'
-    if (Test-Path -LiteralPath $binDir -PathType Container) {
-      $paths += $binDir
-    }
-  }
-
-  return $paths
-}
-
 $staticManagedPaths = @(Get-StaticManagedPaths)
 $managedLookup = @{}
 foreach ($dir in $staticManagedPaths) {
   $managedLookup[(Normalize-PathEntry $dir)] = $true
-}
-
-$misePackagesRoot = Get-MisePackagesRoot
-$misePackagePattern = $null
-if (-not [string]::IsNullOrEmpty($misePackagesRoot)) {
-  $misePackagePattern = '^' +
-    [regex]::Escape((Normalize-PathEntry $misePackagesRoot)) +
-    '\\jdx\.mise_[^\\]+\\mise\\bin$'
 }
 
 $wingetPackagesRoot = Get-WingetPackagesRoot
@@ -241,10 +205,6 @@ function Test-IsManagedPath {
     return $true
   }
 
-  if ($null -ne $misePackagePattern -and $normalized -match $misePackagePattern) {
-    return $true
-  }
-
   foreach ($pattern in $wingetUserPathPatterns) {
     if ($normalized -match $pattern) {
       return $true
@@ -256,7 +216,7 @@ function Test-IsManagedPath {
 
 $desiredManagedPaths = @()
 $desiredLookup = @{}
-foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + (@(Get-MiseManagedPaths)) + $staticManagedPaths)) {
+foreach ($dir in @((@(Get-WingetUserPathManagedPaths)) + $staticManagedPaths)) {
   if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
     continue
   }

--- a/tests/powershell/managed-paths-parity.Tests.ps1
+++ b/tests/powershell/managed-paths-parity.Tests.ps1
@@ -65,6 +65,14 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
 
     New-ManagedPathLayout | Out-Null
 
+    # jdx.mise is now a plain declared package (a repo-shipped
+    # default, see docs/winget-user-path.md), not a hardcoded special
+    # case — declare it here so both surfaces still find a non-empty
+    # managed set through the generic mechanism.
+    $script:BaseWingetManifestPath = 'TestDrive:\winget-manifest-base.json'
+    Set-Content -Path $script:BaseWingetManifestPath -Value '[{"label":"mise","id":"jdx.mise","bin":"mise/bin"}]'
+    $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $script:BaseWingetManifestPath
+
     # ';' not '' — Windows deletes env vars set to empty string,
     # which would fall through to the real registry (see
     # 01-path.Tests.ps1 for the same workaround).
@@ -93,8 +101,6 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     Remove-Item Function:\Split-PathEntries -ErrorAction SilentlyContinue
     Remove-Item Function:\Normalize-PathEntry -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-StaticManagedPaths -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MisePackagesRoot -ErrorAction SilentlyContinue
-    Remove-Item Function:\Get-MiseManagedPaths -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathManifestPath -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetUserPathDeclaredPackages -ErrorAction SilentlyContinue
     Remove-Item Function:\Get-WingetPackagesRoot -ErrorAction SilentlyContinue
@@ -105,6 +111,7 @@ Describe 'managed-paths parity' -Skip:($IsWindows -eq $false) {
     $env:DOTFILES_TEST_REGISTRY_USER_PATH = $null
     $env:DOTFILES_TEST_WINGET_USER_PATH_MANIFEST = $null
     $script:TestWingetPackagesRoot = $null
+    $script:BaseWingetManifestPath = $null
   }
 
   It 'computes the identical managed-path set on both surfaces' {


### PR DESCRIPTION
## Summary

- Ship `jdx.mise` (`bin = "mise/bin"`) as a repo default under `data.wingetUserPath.packages`, merged underneath any user override, in both `.chezmoi.toml.tmpl` and `winget-user-path-packages.json.tmpl`.
- Remove the hardcoded `jdx.mise_*` discovery (`Get-MiseManagedPaths`, `Get-MisePackagesRoot`, `misePackagePattern`) from the shared managed-path source (`lib/managed-paths.ps1`) and its fixture copy — mise is now just another declared package, going through the same generic mechanism introduced in #177.
- Update the test harness so the existing mise PATH scenarios (current bin kept, stale bin removed, ordering) keep passing through the generic mechanism.
- Document the repo default and its override/merge semantics in `docs/winget-user-path.md`.

Closes #178. Parent roadmap: #176.

## Test plan

- [x] `pwsh -c "Invoke-Pester tests/powershell/"` (Linux dev box; Windows-only Describes correctly skip, no discovery/syntax errors)
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 243/243 pass
- [x] Manual end-to-end validation (forcing `$IsWindows` on Linux): a manifest declaring only `jdx.mise` keeps the current bin and drops a stale sibling; a manifest declaring only `gh` no longer surfaces mise even when its directory exists on disk; the rendered default manifest includes `jdx.mise` with `bin=mise/bin`, `enabled=true`.
- [x] `chezmoi execute-template` snippet checks for the `.chezmoi.toml.tmpl` merge block and the manifest template (default-only, user-override, disabled-override cases)
- [x] `npx cspell` / `npx markdownlint-cli2` on all changed files
- [ ] Real Windows CI Pester run (required status check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)