### PR TITLE
fix(ci): register the four CI jobs as required status checks on master

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -172,8 +172,8 @@ registered all four contexts on the ruleset directly.
 
 Per `.github/instructions/idd-ci.instructions.md`, when an IDD run
 reaches the shared CI wait, it builds the required-check set from
-rulesets and branch protection; if neither source yields a check for
-the current PR head, IDD stops and posts a hold for missing
+rulesets and branch protection; if neither source yields a
+required-check set at all, IDD stops and posts a hold for missing
 merge-gate policy evidence rather than silently merging. The
 four-check ruleset above is now that required set.
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -153,32 +153,29 @@ required-check set is partial.
 
 ### Required status checks on `master`
 
-Branch protection's `required_status_checks.contexts` currently lists
-`lint` (from the Linting workflow) and `Lua syntax check` (from the
-Test workflow). The remaining two jobs in the Test workflow —
-`Bash tests (bats)` and `PowerShell tests (Pester)` — are not
-required yet because they fail on `master` baseline for environmental
-reasons (`chezmoi` missing on the Ubuntu runner; 13 Windows-only
-Pester cases). Tracking:
+`master` has no classic branch protection (that API returns 404);
+the gate lives entirely in the default-branch ruleset (`main`, id
+`18861545`, matching `~DEFAULT_BRANCH`). That ruleset's
+`required_status_checks` rule lists all four Test/Linting workflow
+jobs as required: `lint`, `Lua syntax check`, `Bash tests (bats)`,
+and `PowerShell tests (Pester)`.
 
-- [`#109`](https://github.com/kurone-kito/dotfiles/issues/109) —
-  install `chezmoi` in the Bash tests job and promote
-  `Bash tests (bats)` to required.
-- [`#110`](https://github.com/kurone-kito/dotfiles/issues/110) —
-  resolve the 13 Pester failures and promote
-  `PowerShell tests (Pester)` to required.
+[`#109`](https://github.com/kurone-kito/dotfiles/issues/109) and
+[`#110`](https://github.com/kurone-kito/dotfiles/issues/110) (children
+of roadmap [`#107`](https://github.com/kurone-kito/dotfiles/issues/107))
+had already fixed the environmental failures blocking
+`Bash tests (bats)` and `PowerShell tests (Pester)` from being
+promoted (`chezmoi` missing on the Ubuntu runner; 13 Windows-only
+Pester cases), but closed without evidence that the actual promotion
+ran. [`#163`](https://github.com/kurone-kito/dotfiles/issues/163)
+registered all four contexts on the ruleset directly.
 
-Both issues are children of roadmap
-[`#107`](https://github.com/kurone-kito/dotfiles/issues/107).
-
-This is **not** a "no CI gate" situation: per
-`.github/instructions/idd-ci.instructions.md`, when an IDD run reaches
-the shared CI wait, it builds the required-check set from rulesets
-and branch protection. If neither source yields a check for the
-current PR head, IDD stops and posts a hold for missing merge-gate
-policy evidence — it does not silently merge. The current two-check
-floor (`lint` + `Lua syntax check`) is therefore the active merge
-gate, and the two pending promotions tighten it further.
+Per `.github/instructions/idd-ci.instructions.md`, when an IDD run
+reaches the shared CI wait, it builds the required-check set from
+rulesets and branch protection; if neither source yields a check for
+the current PR head, IDD stops and posts a hold for missing
+merge-gate policy evidence rather than silently merging. The
+four-check ruleset above is now that required set.
 
 ### Issue authoring gate
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -153,11 +153,12 @@ required-check set is partial.
 
 ### Required status checks on `master`
 
-`master`'s merge gate is enforced entirely via a default-branch
-ruleset matching `~DEFAULT_BRANCH`, not classic branch protection.
-That ruleset's `required_status_checks` rule lists four required
-check contexts, spanning the Linting and Test workflows: `lint`,
-`Lua syntax check`, `Bash tests (bats)`, and
+`master`'s merge gate currently comes from a default-branch ruleset
+matching `~DEFAULT_BRANCH`; classic branch protection is not
+configured today, though the CI wait unions both sources should that
+change. The ruleset's `required_status_checks` rule lists four
+required check contexts, spanning the Linting and Test workflows:
+`lint`, `Lua syntax check`, `Bash tests (bats)`, and
 `PowerShell tests (Pester)`.
 
 [`#109`](https://github.com/kurone-kito/dotfiles/issues/109) and

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -155,8 +155,8 @@ required-check set is partial.
 
 `master`'s merge gate currently comes from a default-branch ruleset
 matching `~DEFAULT_BRANCH`; classic branch protection is not
-configured today, though the CI wait unions both sources should that
-change. The ruleset's `required_status_checks` rule lists four
+configured today, though the CI wait unions both sources if that
+changes. The ruleset's `required_status_checks` rule lists four
 required check contexts, spanning the Linting and Test workflows:
 `lint`, `Lua syntax check`, `Bash tests (bats)`, and
 `PowerShell tests (Pester)`.

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -153,12 +153,12 @@ required-check set is partial.
 
 ### Required status checks on `master`
 
-`master` has no classic branch protection (that API returns 404);
-the gate lives entirely in the default-branch ruleset (`main`, id
-`18861545`, matching `~DEFAULT_BRANCH`). That ruleset's
-`required_status_checks` rule lists all four Test/Linting workflow
-jobs as required: `lint`, `Lua syntax check`, `Bash tests (bats)`,
-and `PowerShell tests (Pester)`.
+`master`'s merge gate is enforced entirely via a default-branch
+ruleset matching `~DEFAULT_BRANCH`, not classic branch protection.
+That ruleset's `required_status_checks` rule lists four required
+check contexts, spanning the Linting and Test workflows: `lint`,
+`Lua syntax check`, `Bash tests (bats)`, and
+`PowerShell tests (Pester)`.
 
 [`#109`](https://github.com/kurone-kito/dotfiles/issues/109) and
 [`#110`](https://github.com/kurone-kito/dotfiles/issues/110) (children


### PR DESCRIPTION
## Summary

- `master` has no classic branch protection (that API returns 404 — confirmed); the merge gate lives entirely in the default-branch ruleset (`main`, id `18861545`, matching `~DEFAULT_BRANCH`).
- Added a `required_status_checks` rule to that ruleset via `gh api PUT /repos/kurone-kito/dotfiles/rulesets/18861545`, listing the four Test/Linting workflow contexts, verified against a recent merge commit's check-runs: `lint`, `Lua syntax check`, `Bash tests (bats)`, `PowerShell tests (Pester)`. The existing `deletion`/`non_fast_forward`/`pull_request`/`copilot_code_review` rules are preserved unchanged.
- Rewrote the "Required status checks on `master`" section of `docs/idd-policy.md`, which still described a classic-branch-protection two-check floor (`lint` + `Lua syntax check`) that doesn't match how this repo actually gates merges.
- `#109`/`#110` (children of roadmap `#107`) had already fixed the environmental failures blocking `Bash tests (bats)`/`PowerShell tests (Pester)` from being promoted, but closed without evidence that the promotion itself ran; this closes that gap directly.

Closes #163. Parent roadmap: #162.

## Evidence

`gh api repos/kurone-kito/dotfiles/rulesets/18861545` — `required_status_checks` rule now present with all four contexts:

```json
{
  "type": "required_status_checks",
  "parameters": {
    "strict_required_status_checks_policy": false,
    "do_not_enforce_on_create": false,
    "required_status_checks": [
      {"context": "lint"},
      {"context": "Lua syntax check"},
      {"context": "Bash tests (bats)"},
      {"context": "PowerShell tests (Pester)"}
    ]
  }
}
```

This PR itself demonstrates the gate: its own merge will be blocked until all four checks pass.

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `npx cspell` on the changed doc passes
- [ ] This PR's merge is blocked until `lint`, `Lua syntax check`, `Bash tests (bats)`, and `PowerShell tests (Pester)` all pass (demonstrates the new gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)