### PR TITLE
docs: document the Windows-only PowerShell validation methodology for Linux dev environments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -336,6 +336,34 @@ On non-Windows `pwsh`, Windows-only Pester scopes are skipped. The
 authoritative full PowerShell run remains Windows local execution and
 Windows CI.
 
+### Validating Windows-only logic on Linux
+
+A skipped Pester scope proves nothing about the logic inside it — use
+this fallback to gain confidence in Windows-only `conf.d`/`lib`
+changes before pushing, while still treating a real Windows CI Pester
+run as authoritative:
+
+- **Don't force `$IsWindows = $true` inside Pester.** Overriding it
+  via `Set-Variable -Force` to make a Windows-only Describe block
+  execute on Linux breaks Pester's `TestDrive:` provider (its
+  `New-TestRegistry`/`Get-TempRegistry` internals throw), so a forced
+  Pester run isn't a reliable signal either way.
+- **Write a standalone, non-Pester script instead.** Force
+  `$IsWindows = $true` at the top, use a plain OS temp directory in
+  place of `TestDrive:` (e.g.
+  `New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) '...')`),
+  dot-source the subject script directly, and assert with plain
+  PowerShell comparisons (`Should -Be` isn't available outside
+  Pester — compare values directly and `Write-Host` the result).
+- **`[IO.Path]::PathSeparator` still reflects the real host OS**
+  (`:` on Linux) regardless of a forced `$IsWindows` override, since
+  it's a real .NET/OS property, not something the override changes.
+  Use that property consistently in these scripts instead of
+  hardcoding `;`.
+- This only builds local confidence — it is not a substitute for the
+  real Windows CI Pester run (or Windows local execution), which
+  remains the authoritative check.
+
 ### When to run
 
 - **After modifying** any script template in `home/` (especially

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -352,9 +352,11 @@ run as authoritative:
   `$IsWindows = $true` at the top, use a plain OS temp directory in
   place of `TestDrive:` (e.g.
   `New-Item -ItemType Directory -Path (Join-Path ([IO.Path]::GetTempPath()) '...')`),
-  dot-source the subject script directly, and assert with plain
-  PowerShell comparisons (`Should -Be` isn't available outside
-  Pester — compare values directly and `Write-Host` the result).
+  dot-source the subject script directly, and assert with
+  `Import-Module Pester; ... | Should -Be ...` (works fine outside
+  `Invoke-Pester` once the module is imported, and throws on a
+  mismatch instead of silently printing a comparison a human could
+  miss).
 - **`[IO.Path]::PathSeparator` still reflects the real host OS**
   (`:` on Linux) regardless of a forced `$IsWindows` override, since
   it's a real .NET/OS property, not something the override changes.


### PR DESCRIPTION
## Summary

- Add a "Validating Windows-only logic on Linux" subsection to `.github/copilot-instructions.md`'s Testing section, documenting the standalone-script fallback pattern re-derived from scratch across the #177/#178 work: forcing `$IsWindows` on Linux breaks Pester's `TestDrive:` provider, so local confidence in Windows-only `conf.d`/`lib` changes requires a non-Pester script instead.
- Notes the `[IO.Path]::PathSeparator` gotcha (reflects the real host OS regardless of a forced `$IsWindows` override).
- Makes explicit that this is a local-confidence aid only — Windows CI Pester remains authoritative.

Closes #197.

## Test plan

- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `npx cspell` on the changed file passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)