### PR TITLE
test: throwaway docs-only verification round 2 for #198 (do not merge)

### DIFF
--- a/.ci-skip-verification-marker.txt
+++ b/.ci-skip-verification-marker.txt
@@ -1,0 +1,1 @@
+# CI skip verification: non-docs marker, safe to delete

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
       requires_full_ci: ${{ steps.resolve.outputs.value }}
     steps:
       - uses: actions/checkout@v7
+      - name: TEMPORARY deliberate failure for #198 fail-safe verification
+        run: exit 1
       # Only meaningful for pull_request events, which paths-filter
       # resolves via the GitHub API (a reliable full PR-vs-base diff,
       # regardless of how many commits are in the PR). Deliberately
@@ -52,7 +54,13 @@ jobs:
   bash-tests:
     name: Bash tests (bats)
     needs: detect-changes
-    if: needs.detect-changes.outputs.requires_full_ci == 'true'
+    # always() overrides the default "skip if a need failed" behavior
+    # so a failed/cancelled detect-changes fails open to running the
+    # real job, rather than silently skipping it (which would satisfy
+    # the required-status-check gate without ever having run).
+    if: |
+      always() &&
+      (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.requires_full_ci == 'true')
     runs-on: ubuntu-latest
     env:
       CHEZMOI_VERSION: v2.71.0
@@ -83,7 +91,13 @@ jobs:
   powershell-tests:
     name: PowerShell tests (Pester)
     needs: detect-changes
-    if: needs.detect-changes.outputs.requires_full_ci == 'true'
+    # always() overrides the default "skip if a need failed" behavior
+    # so a failed/cancelled detect-changes fails open to running the
+    # real job, rather than silently skipping it (which would satisfy
+    # the required-status-check gate without ever having run).
+    if: |
+      always() &&
+      (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.requires_full_ci == 'true')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
@@ -101,7 +115,13 @@ jobs:
   lua-syntax:
     name: Lua syntax check
     needs: detect-changes
-    if: needs.detect-changes.outputs.requires_full_ci == 'true'
+    # always() overrides the default "skip if a need failed" behavior
+    # so a failed/cancelled detect-changes fails open to running the
+    # real job, rather than silently skipping it (which would satisfy
+    # the required-status-check gate without ever having run).
+    if: |
+      always() &&
+      (needs.detect-changes.result != 'success' || needs.detect-changes.outputs.requires_full_ci == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/.ci-skip-verification-scratch.md
+++ b/docs/.ci-skip-verification-scratch.md
@@ -1,0 +1,5 @@
+# CI skip verification scratch (round 2)
+
+Throwaway file used to verify the docs-only CI skip in #198,
+specifically the push-vs-pull_request event fix. Safe to delete;
+removed before this verification PR is closed.

--- a/docs/.ci-skip-verification-scratch.md
+++ b/docs/.ci-skip-verification-scratch.md
@@ -3,3 +3,6 @@
 Throwaway file used to verify the docs-only CI skip in #198,
 specifically the push-vs-pull_request event fix. Safe to delete;
 removed before this verification PR is closed.
+
+Round 3: this commit also touches a non-docs file, to verify
+`requires_full_ci` correctly evaluates true for a mixed change.


### PR DESCRIPTION
Second disposable verification PR for #198, specifically re-testing the push/pull_request event fix after Copilot correctly found a bug in the first attempt. Will check both the push-triggered AND pull_request-triggered job conclusions individually this time. Will be closed and the branch deleted once verified — do not merge.