### PR TITLE
fix(git): remove duplicate $@ forwarding in ssh signing aliases

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -70,9 +70,9 @@
        signing via `commit.gpgsign=true` / `tag.gpgsign=true` so
        they also work in scopes that have no primary signing set. */ -}}
 {{- $sshAbsPath := printf "%s/.ssh/%s.pub" $homeDir $sshFallbackFile }}
-  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f \"$@\""
-  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f \"$@\""
-  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f \"$@\""
+  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f"
+  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f"
+  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f"
 {{- end }}
 [add "interactive"]
   useBuiltin = true

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -66,6 +66,38 @@ JSON
   assert_output --partial 'rebase-ssh ='
 }
 
+@test "config: commit-ssh alias forwards extra arguments exactly once" {
+  cat > "$TMP_CFG" <<'JSON'
+{ "data": { "secret": { "ssh": { "keys": {
+  "personal": { "item": "i", "filename": "id_ed25519_personal", "signing_fallback": true }
+} } } } }
+JSON
+  run _render "$CONFIG_TMPL"
+  assert_success
+  local rendered="$BATS_TEST_TMPDIR/rendered-config"
+  echo "$output" > "$rendered"
+
+  local scratch="$BATS_TEST_TMPDIR/scratch"
+  mkdir -p "$scratch"
+  git -C "$scratch" init -q
+  git -C "$scratch" config user.email "test@example.com"
+  git -C "$scratch" config user.name "Test"
+
+  local alias_value
+  alias_value=$(git config -f "$rendered" --get alias.commit-ssh)
+  git -C "$scratch" config alias.commit-ssh "$alias_value"
+
+  # Git's `!`-alias mechanism already forwards extra CLI args by
+  # appending a single "$@" to the alias body; a stray outer "$@" in
+  # the alias itself would forward them a second time. That second
+  # copy lands after the first "--", so "-m" leaks through as a
+  # pathspec instead of being consumed once as the message flag.
+  run git -C "$scratch" commit-ssh -m msg -- no-such-file.txt
+  assert_failure
+  assert_output --partial "pathspec 'no-such-file.txt' did not match"
+  refute_output --partial "pathspec '-m'"
+}
+
 @test "config: GPG fpr + signing_fallback keeps GPG primary, adds SSH aliases" {
   cat > "$TMP_CFG" <<'JSON'
 { "data": {


### PR DESCRIPTION
## Summary

- `home/dot_config/git/config.tmpl`: the `commit-ssh` / `tag-ssh` /
  `rebase-ssh` aliases wrote an explicit `"$@"` at their outer `f "$@"`
  call site. Git's `!`-shell alias mechanism already appends a single
  `"$@"` to the command string when the alias runs with extra
  arguments, so every argument was forwarded **twice**. Dropped only
  the redundant outer copy (`; f "$@"` -> `; f`); the inner
  `commit "$@"` / `tag "$@"` / `rebase "$@"` calls are untouched, and
  the aliases now match the correct idiom already used by
  `delete-merged-branches` in the same file.
- `tests/bash/signing-resolve.bats`: added a regression test that
  registers the rendered `commit-ssh` alias in a scratch git repo and
  asserts arguments are forwarded exactly once.

Closes #203

## Why this matters

Empirically confirmed impact of the bug before this fix:

- `git commit-ssh -m "msg"` silently doubled the commit message body
  to two paragraphs — no error, just wrong content.
- `git commit-ssh -m msg -- somefile` failed with pathspec errors,
  because the duplicated tokens land after the first `--` and stop
  being parsed as options.
- `git rebase-ssh main`, run from a feature branch, actually executed
  `git rebase main main` (git's two-argument `<upstream> <branch>`
  form), which silently checked out `main` and did nothing to the
  feature branch, while exiting 0 with a misleading "Current branch
  main is up to date." message.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 238/244
      passing. The 6 failures (`60-mise.bats`, MISE_TRUSTED_CONFIG_PATHS
      / ghq-trusted-paths) are pre-existing and unrelated to this
      change: they reproduce identically on unmodified `master` in
      this sandbox (a WSL box picking up a Windows-side `mise` config
      path), and the `Test workflow` CI run already passed on the
      current `master` HEAD (605cd56).
- [x] `pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` —
      199/204 passing. The 5 failures (PSFzf/PSReadLine chord setup,
      OnIdle subscription, tailscale serve) are likewise pre-existing
      and unrelated, reproducing identically on unmodified `master`.
- [x] Manual red/green verification: registered the exact rendered
      pre-fix alias body in a scratch repo and confirmed
      `git commit-ssh -m msg -- no-such-file.txt` produces 5 pathspec
      errors including a leaked `pathspec '-m'`; the fixed alias body
      produces exactly one (`no-such-file.txt`).
- [x] `npx markdownlint-cli2 --fix && npx markdownlint-cli2` — clean
      (no Markdown touched by this change).
