### PR TITLE
fix(git): remove duplicate $@ forwarding in per-profile ssh signing aliases

### DIFF
--- a/home/run_onchange_after_generate-git-profiles.sh.tmpl
+++ b/home/run_onchange_after_generate-git-profiles.sh.tmpl
@@ -51,9 +51,9 @@ cat > "${profiles_dir}/{{ $key }}" << 'PROFILE_EOF'
 {{- end }}
 {{- if $sshFile }}
 [alias]
-  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f \"$@\""
-  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f \"$@\""
-  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f \"$@\""
+  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f"
+  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f"
+  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f"
 {{- end }}
 PROFILE_EOF
 {{ end -}}

--- a/tests/bash/signing-resolve.bats
+++ b/tests/bash/signing-resolve.bats
@@ -206,6 +206,45 @@ JSON
   assert_output --partial '/.ssh/id_work.pub'
 }
 
+@test "profiles: commit-ssh alias forwards extra arguments exactly once" {
+  cat > "$TMP_CFG" <<'JSON'
+{ "data": {
+  "git": { "profiles": { "work": { "name": "W", "email": "w@e", "gitdir": "~/w/" } } },
+  "secret": { "ssh": { "keys": {
+    "p": { "item": "i", "filename": "id_work", "signing_profiles": ["work"] }
+  } } }
+} }
+JSON
+  run _render "$PROFILES_TMPL"
+  assert_success
+  local rendered_script="$BATS_TEST_TMPDIR/rendered-script"
+  echo "$output" > "$rendered_script"
+
+  # The rendered output is the generator *shell script* source, which
+  # writes the profile gitconfig via a heredoc; extract the heredoc
+  # body itself so it can be read as a real gitconfig file.
+  local rendered_profile="$BATS_TEST_TMPDIR/rendered-profile"
+  sed -n "/<< 'PROFILE_EOF'/,/^PROFILE_EOF\$/p" "$rendered_script" | sed '1d;$d' > "$rendered_profile"
+
+  local scratch="$BATS_TEST_TMPDIR/scratch"
+  mkdir -p "$scratch"
+  git -C "$scratch" init -q
+  git -C "$scratch" config user.email "test@example.com"
+  git -C "$scratch" config user.name "Test"
+
+  local alias_value
+  alias_value=$(git config -f "$rendered_profile" --get alias.commit-ssh)
+  git -C "$scratch" config alias.commit-ssh "$alias_value"
+
+  # Same duplication risk as the global commit-ssh alias: a stray
+  # outer "$@" would forward every argument twice, leaking "-m" past
+  # the first "--" as a bogus pathspec.
+  run git -C "$scratch" commit-ssh -m msg -- no-such-file.txt
+  assert_failure
+  assert_output --partial "pathspec 'no-such-file.txt' did not match"
+  refute_output --partial "pathspec '-m'"
+}
+
 @test "profiles: SSH-only profile (no GPG signingkey) emits ssh format + aliases" {
   cat > "$TMP_CFG" <<'JSON'
 { "data": {


### PR DESCRIPTION
## Summary

Follow-up to #203 / #204: the same double-argument-forwarding bug also
existed in a second, independent template.

- `home/run_onchange_after_generate-git-profiles.sh.tmpl`: the
  per-profile `commit-ssh` / `tag-ssh` / `rebase-ssh` aliases
  (profile-scoped SSH signing fallback) had the identical redundant
  outer `"$@"` bug already fixed for the global aliases in #204.
  Dropped only the redundant outer copy (`; f "$@"` -> `; f`); inner
  `commit "$@"` / `tag "$@"` / `rebase "$@"` untouched.
- `tests/bash/signing-resolve.bats`: added a regression test to the
  `profiles:` group mirroring #204's test — extracts the rendered
  heredoc body (this template generates a shell script that writes the
  profile gitconfig via a heredoc, rather than rendering the gitconfig
  directly) and asserts single (not double) argument forwarding for
  `commit-ssh`.

Closes #205

## Why this matters

This template was missed when #203 was originally filed/fixed — only
the global `config.tmpl` aliases were addressed. Anyone using a
per-profile SSH signing fallback (`includeIf "gitdir:..."` profiles)
still had the double-forwarding bug: silently doubled commit messages
via `-m`, pathspec errors with `-- path`, and `rebase-ssh <upstream>`
silently checking out `<upstream>` instead of rebasing — same failure
modes empirically demonstrated for the global aliases in #203.

## Test plan

- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — 239/245
      passing. The 6 failures (`60-mise.bats`) are pre-existing and
      unrelated (reproduce identically on unmodified `master` in this
      sandbox; CI passes them).
- [x] `pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` —
      199/204 passing. The 5 failures are likewise pre-existing and
      unrelated (reproduce identically on unmodified `master`).
- [x] Manual red/green verification: the pre-fix alias (reverted in a
      scratch copy) reproduces 5 pathspec errors including a leaked
      `pathspec '-m'`; the fixed alias produces exactly one.
- [x] `npx markdownlint-cli2 --fix && npx markdownlint-cli2` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed SSH-signed Git aliases so command-line arguments are forwarded correctly for commits, tags, and rebases.
  - Prevented options such as commit messages from being misinterpreted as file paths when using these aliases.
  - Added validation to ensure extra arguments behave as expected in generated profile configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->