### PR TITLE
fix(pwsh): remove duplicate $@ forwarding in per-profile ssh signing aliases

### DIFF
--- a/home/run_onchange_after_generate-git-profiles.ps1.tmpl
+++ b/home/run_onchange_after_generate-git-profiles.ps1.tmpl
@@ -49,9 +49,9 @@ $profilePath = Join-Path $profilesDir '{{ $key }}'
 {{- end }}
 {{- if $sshFile }}
 [alias]
-  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f \"$@\""
-  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f \"$@\""
-  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f \"$@\""
+  commit-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' commit \"$@\"; }; f"
+  tag-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'tag.gpgsign=true' tag \"$@\"; }; f"
+  rebase-ssh = "!f() { git -c 'gpg.format=ssh' -c 'user.signingkey={{ $sshAbsPath }}' -c 'commit.gpgsign=true' rebase \"$@\"; }; f"
 {{- end }}
 '@ | Set-Content -Path $profilePath -Encoding utf8NoBOM
 {{- end }}

--- a/tests/powershell/signing-resolve.Tests.ps1
+++ b/tests/powershell/signing-resolve.Tests.ps1
@@ -123,6 +123,42 @@ Describe 'signing-resolve' -Skip:(-not $script:HasChezmoi) {
       $r.Output   | Should -Match '/\.ssh/id_work\.pub'
     }
 
+    It 'commit-ssh alias forwards extra arguments exactly once' {
+      $json = '{ "data": { "git": { "profiles": { "work": { "name": "W", "email": "w@e", "gitdir": "~/w/" } } }, "secret": { "ssh": { "keys": { "p": { "item": "i", "filename": "id_work", "signing_profiles": ["work"] } } } } } }'
+      $r = Invoke-Render $script:ProfilesTmpl $json
+      $r.ExitCode | Should -Be 0
+
+      # The rendered output is the generator *script* source, which
+      # writes the profile gitconfig via a here-string; extract the
+      # here-string body so it can be read as a real gitconfig file.
+      if ($r.Output -notmatch "(?ms)^@'\r?\n(.*?)\r?\n^'@") {
+        throw 'Could not locate the profile here-string in rendered output'
+      }
+      $renderedProfile = Join-Path ([IO.Path]::GetTempPath()) ("signing-{0}-profile" -f [guid]::NewGuid())
+      Set-Content -Path $renderedProfile -Value $Matches[1] -Encoding utf8NoBOM
+
+      $scratch = Join-Path ([IO.Path]::GetTempPath()) ("signing-{0}-scratch" -f [guid]::NewGuid())
+      New-Item -ItemType Directory -Path $scratch -Force | Out-Null
+      try {
+        & git -C $scratch init -q
+        & git -C $scratch config user.email 'test@example.com'
+        & git -C $scratch config user.name 'Test'
+
+        $aliasValue = & git config -f $renderedProfile --get alias.commit-ssh
+        & git -C $scratch config alias.commit-ssh $aliasValue
+
+        # Same duplication risk as the global commit-ssh alias: a
+        # stray outer "$@" would forward every argument twice, leaking
+        # "-m" past the first "--" as a bogus pathspec.
+        $out = & git -C $scratch commit-ssh -m msg -- no-such-file.txt 2>&1
+        $LASTEXITCODE | Should -Not -Be 0
+        ($out -join "`n") | Should -Match "pathspec 'no-such-file.txt' did not match"
+        ($out -join "`n") | Should -Not -Match "pathspec '-m'"
+      } finally {
+        Remove-Item -Path $renderedProfile, $scratch -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    }
+
     It 'SSH-only profile (no GPG signingkey) emits ssh format + aliases' {
       $json = '{ "data": { "git": { "profiles": { "work": { "name": "W", "email": "w@e", "gitdir": "~/w/" } } }, "secret": { "ssh": { "keys": { "p": { "item": "i", "filename": "id_work", "signing_profiles": ["work"] } } } } } }'
       $r = Invoke-Render $script:ProfilesTmpl $json


### PR DESCRIPTION
## Summary

Third and final part of the #203 bug-fix chain: the same
double-argument-forwarding bug also existed in the PowerShell sibling
of the per-profile generator template.

- `home/run_onchange_after_generate-git-profiles.ps1.tmpl`: the
  per-profile `commit-ssh` / `tag-ssh` / `rebase-ssh` aliases had the
  identical redundant outer `"$@"` bug already fixed for the global
  aliases in #204 and the POSIX per-profile generator in #206. Dropped
  only the redundant outer copy (`; f "$@"` -> `; f`); inner
  `commit "$@"` / `tag "$@"` / `rebase "$@"` untouched.
- `tests/powershell/signing-resolve.Tests.ps1`: added a Pester
  regression test mirroring #206's bats test — extracts the rendered
  here-string body (this template generates a PowerShell script that
  writes the profile gitconfig via a here-string, rather than
  rendering the gitconfig directly) and asserts single (not double)
  argument forwarding for `commit-ssh`.

Closes #207

## Why this matters

This PowerShell template was missed in both #203 and #205 because
neither issue's investigation checked the `.ps1.tmpl` sibling of the
templates that were fixed — the same class of gap as PR #180
(`gpg-cache`), which needed the identical fix applied to both its
POSIX and PowerShell variants.

## Test plan

- [x] `pwsh -c "Invoke-Pester tests/powershell/ -Output Detailed"` —
      200/204 passing. The 5 failures (PSFzf/PSReadLine, OnIdle,
      tailscale) are pre-existing and unrelated, reproducing
      identically on unmodified `master`.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` — unaffected
      (239/245, same 6 pre-existing `60-mise.bats` failures as
      `master`); this change touches no `.sh`/`.bats` files.
- [x] Manual red/green verification: the pre-fix alias (reverted in a
      scratch copy) reproduces 5 pathspec errors including a leaked
      `pathspec '-m'`; the fixed alias produces exactly one.
- [x] `npx markdownlint-cli2 --fix && npx markdownlint-cli2` — clean.

**Known limitation**: this sandbox runs `pwsh` on Linux; the new test
is only empirically verified there. Per this repo's own testing
doctrine, the authoritative PowerShell signal for Windows-specific
behavior is Windows local execution / Windows CI (no Windows Pester
CI leg exists yet — tracked separately by #166). The new test's
`git config alias.commit-ssh <value>` + native-command invocation
pattern is new to this file; a Windows PS5.1 re-run would be good
follow-up confirmation, though this is a pre-existing repo-wide gap,
not something introduced by this change.
