### PR TITLE
feat(idd): update issue-authoring companion bundle to 0.4.0 contract

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -20,7 +20,11 @@ Use two stable phases:
    ask only the questions that block safe issue drafting. Keep
    clarification bounded; use the repository-local
    `issueAuthoring.maxClarificationRounds` value when available,
-   otherwise default to 3 rounds.
+   otherwise default to 3 rounds. **Under-clarification stop rule**: if,
+   after bounded clarification, you still cannot name the concrete
+   surface to edit or an objective verification for a candidate task,
+   route it to `needs-decision` or ask — do not publish a
+   confidently-vague `ready` issue. Reliability over speed.
 2. **Decompose and Draft** — restate the request in implementation
    terms, split it into atomic tasks, classify readiness, reuse existing
    issues when safe, and draft the smallest issue shape that preserves
@@ -33,19 +37,26 @@ needs-decision, blocked-by-human, and out-of-scope.
 
 1. Read the bundled contract in
    [references/contract.md](references/contract.md).
-2. Reuse or extend an existing issue before creating a new one.
+2. Reuse or extend an existing issue before creating a new one — but
+   never edit the body of an actively-claimed or open-PR issue (its
+   claimed agent will not pick the change up); cover it with a follow-up
+   issue instead. See the contract's claim-state precondition.
 3. Choose the smallest safe output shape:
    - orphan issue for one ready autonomous task only when the target
-     repository is discoverable through `issue-scope: orphan-first` and
-     any configured `orphan-first-policy` approval step can be completed
+     repository discovers orphans (`issue-scope: roadmap-first`, the
+     default, via the orphan fallback, or `orphan-first`) and any
+     configured `orphan-first-policy` approval step can be completed
      after drafting
    - roadmap plus sub-issues for multi-task or multi-session work
    - stable non-ready buckets for deferred, needs-decision,
      blocked-by-human, or out-of-scope work
-4. Resolve the target repository marker prefix before drafting hidden
-   dependency markers. Use the prefix documented by the target
-   repository's onboarding or IDD docs, and ask the user instead of
-   guessing when the prefix is not discoverable.
+4. **Prefix-first**: resolve the target repository's marker prefix
+   before emitting any authoring marker — `roadmap-id`, `blocked-by`,
+   `autopilot-suitability`, or `effort`. Use the prefix documented by
+   the target repository's onboarding or IDD docs, and ask the user
+   instead of guessing when the prefix is not discoverable. Never
+   default to this source repository's `idd-skill` prefix in an
+   installed bundle.
 5. Keep dependencies machine-readable and minimal:
    - roadmap identity via
      `<!-- <marker-prefix>-roadmap-id: ... -->`
@@ -58,7 +69,14 @@ needs-decision, blocked-by-human, and out-of-scope.
    - keep independent sibling work in roadmap task lists unless a true
      correctness, availability, or ordering constraint requires a
      dependency edge
-6. When the user explicitly authorizes publication, manage the authoring
+6. Before publishing a ready orphan, roadmap, or child body, run the
+   `audit-authored-issue` linter against it as the mechanical
+   pre-publish gate — see
+   [Mechanical pre-publish gate](references/contract.md#mechanical-pre-publish-gate)
+   in the bundled contract, including the manual fallback for
+   `instructions-only` installs with no helper runtime. Resolve every
+   reported failure before treating the issue as ready.
+7. When the user explicitly authorizes publication, manage the authoring
    label for each created or updated issue:
    - resolve `issueAuthoring.authoringLabelName`, defaulting to
      `status:authoring`
@@ -68,13 +86,15 @@ needs-decision, blocked-by-human, and out-of-scope.
    - apply the label before updating an existing issue
    - create new issues with the label when supported, or apply the label
      immediately after creation
-   - if post-create label application fails, close, delete, or otherwise
-     make the created issue undiscoverable before stopping
+   - if post-create label application fails, close the created issue
+     before stopping; deletion needs admin permission the authoring
+     agent typically lacks (and `docs/permissions.md` forbids for normal
+     IDD), so it is not the default path
    - remove the label from all published issues only after the full set is
      published, the user confirms the result, and the user explicitly
      requests release from the authoring hold for IDD execution
    - leave the label in place if publishing is interrupted before release
-7. Stop at the approval boundary. Drafting issues does not authorize
+8. Stop at the approval boundary. Drafting issues does not authorize
    publishing them or starting the IDD execution loop unless the user
    explicitly asked for that.
 
@@ -87,12 +107,13 @@ needs-decision, blocked-by-human, and out-of-scope.
   [references/workflow-boundary.md](references/workflow-boundary.md).
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
+<!-- dotfiles-divergence: installed-bundle-reference-routing -->
 - This is an installed companion bundle, not the source-repository
   copy. When the upstream bundle changes, re-import from the canonical
   maintenance docs in
-  [`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/issue-authoring-skill.md)
+  [`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d/docs/issue-authoring-skill.md)
   and
-  [`kurone-kito/idd-skill:docs/idd-workflow.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/idd-workflow.md);
+  [`kurone-kito/idd-skill:docs/idd-workflow.md`](https://github.com/kurone-kito/idd-skill/blob/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d/docs/idd-workflow.md);
   the corresponding in-repo copy of the workflow doc is at
   [`../../../docs/idd-workflow.md`](../../../docs/idd-workflow.md).
 
@@ -109,3 +130,12 @@ needs-decision, blocked-by-human, and out-of-scope.
   new issue.
 - Avoid widening drafting output beyond the user request without saying
   so.
+- Run the `audit-authored-issue` linter (or its manual fallback in
+  `instructions-only` installs) against every drafted ready body and
+  resolve every reported failure before publishing.
+- Name a concrete surface to edit and an objective verification for
+  every `ready` candidate; route anything else to `needs-decision` or
+  ask instead of guessing (the under-clarification stop rule).
+- Resolve the target repository's marker prefix before emitting any
+  authoring marker; never assume this source repository's `idd-skill`
+  prefix in an installed bundle (the prefix-first rule).

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -1,21 +1,25 @@
+<!-- dotfiles-divergence: installed-bundle-reference-routing -->
 # Bundled Issue Authoring Contract
 
 This file keeps the `issue-authoring` bundle usable when it is installed
 or copied outside its source repository. It mirrors the canonical
 contract maintained upstream at
-[`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/docs/issue-authoring-skill.md).
+[`kurone-kito/idd-skill:docs/issue-authoring-skill.md`](https://github.com/kurone-kito/idd-skill/blob/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d/docs/issue-authoring-skill.md).
 
 ## Target marker prefix
 
-Resolve the target repository's hidden marker prefix before drafting any
-roadmap or blocked-by marker.
+**Prefix-first**: resolve the target repository's hidden marker prefix
+before emitting _any_ authoring marker — `roadmap-id`, `blocked-by`,
+`autopilot-suitability`, or `effort`. Resolve it once, up front, not as
+an afterthought once a marker is already half-drafted.
 
+<!-- dotfiles-divergence: installed-bundle-reference-routing -->
 - Use the prefix documented by the target repository's onboarding or
   IDD instructions.
 - For this repository, the configured prefix is `dotfiles` (see
   `.github/idd/config.json#markerPrefix`). Installed bundles in other
   repositories must read the local config rather than copying this
-  value.
+  value; never default to `idd-skill` in an installed bundle.
 - If the prefix is not discoverable from the repository docs or user
   context, stop and ask instead of emitting a guessed marker.
 
@@ -61,6 +65,15 @@ locally. Clarification must be bounded; use the repository-local
 otherwise default to 3 rounds. If safe drafting is still impossible
 after that, stop and report the remaining blockers instead of looping
 indefinitely.
+
+**Under-clarification stop rule.** If, after bounded clarification, you
+still cannot name the concrete surface to edit or an objective
+verification for a candidate task, route it to `needs-decision` or ask
+— do not publish a confidently-vague `ready` issue. Reliability over
+speed. This is distinct from the "Under-specified" specificity band
+below: that band judges an already-drafted body's wording, while this
+rule stops publication earlier, during Intake, before a body is even
+drafted.
 
 ### 2. Decompose and Draft
 
@@ -123,12 +136,74 @@ issue that passes those gates can still be under-specified if it leaves
 too much implementation shape implicit. The drafting target is therefore
 "ready and stable for a middle-tier model," not "maximally detailed."
 
+## Executability gate for code spec-units
+
+For a **code spec-unit** — a drafted unit whose acceptance criteria are
+objectively executable (a script, function, or test the drafted issue
+itself specifies) — an authoring session can validate the draft before
+publishing by building a throwaway reference implementation against its
+own stated acceptance check and accepting the draft only if that
+reference implementation passes. This reuses the downstream execution
+loop as an upstream ground-truth gate: it catches drafts whose
+acceptance criteria are internally inconsistent, non-trivially
+unsatisfiable, or otherwise not actually implementable, before a
+downstream executor ever claims the issue. The reference implementation
+is a discarded validation probe, never published — it does not cross the
+Publication boundary below; only the drafted issue itself is published,
+and building the probe does not start the IDD execution loop.
+
+This is a **recommended practice for repositories or domains where a
+drafted code spec-unit has an objectively executable acceptance
+check**, not a change to this repository's own mechanical
+`bin/idd-audit-authored-issue.mjs` checks or a new requirement on this
+repository's own issue-authoring practice — most of this repository's
+issues are multi-file engineering changes without a single executable
+acceptance check to validate against.
+
+- **Weak-model semantic self-review stays advisory.** When a weak
+  authoring model reviews its own draft for semantic quality, treat the
+  verdict as advisory only, never a hard veto on publishing — mirroring
+  the narrow-question guidance for weak-model judgment calls in
+  `docs/idd-workflow.md`'s Weak-model guardrails section.
+- **Decompose and draft want different model traits.** Decomposition
+  (judgment about scope and structure) tolerates a verbose reasoning
+  model; the structured draft step (emitting the exact spec/acceptance-
+  criteria block) is more reliable on a leaner, more literal model,
+  whose chain-of-thought does not compete with the drafted block for
+  token budget. Pick the model per sub-task, not per pipeline, when both
+  are available.
+- **Redraft and re-decomposition are limited rescue mechanisms, not
+  reliable fixes.** A bounded redraft loop tends to re-roll rather than
+  converge, because a weak author regenerates rather than incrementally
+  fixes. Re-decomposing a repeatedly-failing unit is usually low-value
+  too: most authoring failures are hard-but-atomic rather than
+  over-broad, and splitting a hard-but-atomic unit tends to produce
+  incoherent sub-units that do not recompose. Treat a code spec-unit
+  that repeatedly fails this gate as a candidate for `needs-decision` or
+  human/stronger-model authoring instead of looping indefinitely.
+
 ## Reuse-first issue policy
 
 Before creating any new issue, check whether the work already has a
 suitable home.
 
-Apply these checks in order:
+**Claim-state precondition (check this first).** Before reusing or
+extending _any_ existing issue, determine whether it has an **active
+claim** (its latest valid `claimed-by` comment is newer than the
+configured `claim-stale-age`; distributed default 24 h) or an **open
+PR**, or is otherwise actively executing. If so, you **MUST NOT edit its
+body**: the working agent snapshots the issue body into its B2 plan and
+treats that plan as authoritative — it never re-reads the body, so a
+post-claim body edit is silently lost and becomes an implementation gap.
+You **may** add a separate **comment** (never an edit or append to the
+body), but **must not** rely on the claimed agent acting on it. Cover
+the intended change with a **follow-up issue** (or a roadmap track around
+it), and you **SHOULD** post a cross-reference comment on the claimed
+issue linking the follow-up. Stale or reclaimable claims (latest
+`claimed-by` older than `claim-stale-age`) are exempt — the next claimer
+re-reads the latest body, so editing them is safe.
+
+Then apply these checks in order:
 
 1. If an existing open issue already matches the task and only lacks the
    new schema details, extend that issue instead of cloning it.
@@ -136,28 +211,68 @@ Apply these checks in order:
    refine task-list entries there instead of creating a competing
    umbrella.
 3. If an existing issue is close but too broad, split follow-up work
-   out of it rather than widening the original issue further.
-4. If an existing issue is already claimed, has an open PR, or is
-   otherwise being actively executed, avoid repurposing it. Create a
-   follow-up issue or extend the roadmap around it instead.
+   out of it rather than widening the original issue further. When the
+   issue being split is itself a roadmap child, update the parent
+   roadmap's `## Tracks` list in the same authoring action — add the
+   new issue's link and adjust any sequencing notes (a short dated note
+   is the observed good pattern) — subject to the claim-state
+   precondition above applied to the roadmap issue's own claim/PR
+   state, and record the provenance in the new issue's body (e.g.,
+   `Split out of #<n>`).
+4. If an existing issue has an **active claim**, an open PR, or is
+   otherwise being actively executed, do **not** edit its body or
+   repurpose it (see the claim-state precondition, which exempts
+   stale/reclaimable claims); create a follow-up issue or extend the
+   roadmap around it instead.
 5. Create a brand-new issue only when no existing issue can absorb the
    work without harming ownership, clarity, or reviewability.
 
 Report when the bundle reuses, extends, or declines to reuse an issue
 so a later session can follow the reasoning.
 
+**Recent-window scan for just-discovered problems.** The checks above
+assume the work already has a candidate home to reuse or extend. When
+instead authoring an ad hoc issue for a problem **just discovered**
+during the current session — a build-breaking regression noticed
+mid-session, for example, rather than a task drafted from an existing
+backlog — run a recent-window duplicate scan immediately before
+publishing: list the newest issues regardless of state and check
+whether a concurrent session already authored the same problem.
+
+```sh
+gh issue list --repo <owner>/<repo> --state all --limit 20
+# or, scoped to a recency window:
+gh issue list --repo <owner>/<repo> --state all --search "created:>=<YYYY-MM-DD>"
+```
+
+A hit routes back into the checks above: extend the discovered issue
+instead of publishing a duplicate. When the race slips past this scan
+anyway (near-simultaneous discovery), the outcome is **anticipated and
+self-resolving, not a coordination failure**: both sessions proceed
+independently through their own claim and implementation cycle;
+whichever PR merges first wins; the other session manually verifies
+the fix already landed on the default branch, then closes its own
+issue and (unmerged) PR as superseded, citing the verifying evidence.
+This is the same manual verify-then-close judgment call the execution
+loop's B2.0 supersession re-check (`idd-work.instructions.md`) applies
+after claim — this scan only adds an earlier, pre-publish checkpoint.
+A fast enough race can still surface even after B2.0; when it does, it
+resolves the same way.
+
 ## Output chooser
 
 Choose the smallest safe output shape:
 
 - **Orphan issue**: one autonomous task can finish the work, no
-  roadmap-level coordination is needed, and the target repository is
-  discoverable through `issue-scope: orphan-first`. If the repository
-  also uses `orphan-first-policy: maintainer-approved`, surface the
-  required post-publication maintainer approval step. If the repository
-  keeps the default `issue-scope: roadmap` or disables public
-  orphan-first discovery with `orphan-first-policy: public-disabled`,
-  surface that constraint and prefer a roadmap package instead.
+  roadmap-level coordination is needed, and the target repository
+  discovers orphans — i.e. `issue-scope` is `roadmap-first` (the
+  default; orphans are picked up as the fallback when no roadmap work is
+  startable) or `orphan-first` (orphans first). If the repository uses
+  `orphan-first-policy: maintainer-approved`, surface the required
+  post-publication maintainer approval step. If the repository sets
+  `issue-scope: roadmap` (roadmap-only) or disables public orphan-first
+  discovery with `orphan-first-policy: public-disabled`, surface that
+  constraint and prefer a roadmap package instead.
 - **Roadmap plus sub-issues**: the request needs visible sequencing,
   parallel tracks, multiple ready issues, or multi-session handoff.
 - **Stable non-ready buckets**: some work is deferred, blocked by a
@@ -245,6 +360,36 @@ choice does not by itself make an otherwise autonomous issue non-ready.
 The ready issue should still carry its own objective verification even
 when a human will look at the result afterward.
 
+## Codebase-fidelity validation
+
+Before publishing a `ready` issue, run a short pre-publication check that
+the spec stays faithful to the existing codebase. Treat this as a routing
+aid, not a rigid wording linter: A4.5 suitability triage is structural and
+does not read the codebase, so a spec that contradicts established
+semantics can still pass that gate and only surface the mismatch in
+advisory review, costing extra review-fix round-trips.
+
+Ask these checks:
+
+1. When an issue reuses an existing identifier or field name, confirm the
+   specified value matches that name's established semantics in the
+   codebase — do not overload a name with a new shape or source.
+2. Flag values that are mutable at runtime — specify a live read at the
+   point of use rather than a one-time capture at construction.
+3. When an issue proposes to **delete, replace, or "align to upstream"**
+   code, first check the target for an intentional-divergence signal — a
+   local change made on purpose to differ from upstream. If one is present,
+   require the issue body to acknowledge that divergence and justify
+   overriding it, rather than silently reverting hardening a consumer added
+   deliberately (blind "resync to upstream" resets are a recurring
+   Discover→plan-cycle waste when the divergence turns out to be
+   intentional). The recommended portable signal is a canonical inline
+   code-comment convention (for example a `do-not-revert:` / `idd-divergence:`
+   marker) — it travels with vendored files and needs no repo-wide label
+   taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
+   also serve, but the code-comment convention is the recommended default.
+   Do not hard-code any single consumer's divergence-tracking mechanism.
+
 ## Dependency minimization
 
 Encode a dependency edge only when it reflects a true correctness,
@@ -259,6 +404,23 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
+- when authoring a **docs or operator-help child that documents
+  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
+  those implementation issues (or otherwise sequence the docs child to run
+  after they merge) so the documentation is written against **shipped**
+  behavior. Describing designed-but-unshipped behavior in the present
+  tense is a recurring advisory-review-thrash pattern; "describe shipped
+  behavior" is a true ordering constraint, so this edge is consistent
+  with the encode-only-a-real-constraint rule above
+- when authoring a **finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**, encode
+  `Blocked by #NNN` on **each** such sibling rather than stating the
+  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
+  edge, not a prose "runs after the siblings" note: A4.5 Actionability
+  inspects the body, not completability, so a prose-sequenced finalize
+  track reports startable the moment its build foundation closes, and
+  claiming it then means either failing its acceptance criteria or doing
+  the siblings' unmerged work
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves
@@ -312,6 +474,13 @@ Validation expectations:
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker;
+  see [Autopilot-suitability score](#autopilot-suitability-score))
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -320,6 +489,10 @@ Validation expectations:
 - acceptance criteria are explicitly verifiable
 - the issue stays discoverable under the target repository's
   `issue-scope` setting
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `orphan` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ### Roadmap issue
 
@@ -329,6 +502,12 @@ Validation expectations:
 - `## Tracks`
 - `## Success criteria`
 - one `<!-- <marker-prefix>-roadmap-id: <roadmap-id> -->` marker
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -339,6 +518,10 @@ Validation expectations:
 - each dependency edge is justified and preserves natural cohesion
 - nested roadmap entries stay identifiable as coordination/audit nodes
   instead of normal execution leaves
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `roadmap` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ### Child issue under a roadmap
 
@@ -347,6 +530,12 @@ Validation expectations:
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
+- an optional effort footer next to it (visible line +
+  `<!-- <marker-prefix>-effort: S|M|L -->` marker; see
+  [Effort hint](#effort-hint)) — a soft Discover selection tie-breaker,
+  fail-safe on absence
 
 Validation expectations:
 
@@ -355,6 +544,10 @@ Validation expectations:
 - any dependency marker is resolvable, intentionally chosen, and
   justified
 - the issue can be claimed independently without absorbing sibling work
+- exactly one autopilot-suitability footer with an integer 1-5
+  marker; a score of `1` also carries `status:blocked-by-human`
+- passes the `audit-authored-issue` mechanical pre-publish gate for the
+  `child` shape (see [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 ## A4.5 Suitability Gate Alignment
 
@@ -383,10 +576,273 @@ Pre-publish validation checklist:
 4. **Human dependency isolation**: Ready issues do not hide unresolved
    decisions, credentials, subjective approvals, or mid-implementation
    human handoffs
+5. **Mechanical audit**: the drafted body passes the
+   `audit-authored-issue` linter for its declared shape (see
+   [Mechanical pre-publish gate](#mechanical-pre-publish-gate))
 
 If any check is uncertain, route the issue to `needs-decision` or
 `blocked-by-human` during drafting instead of publishing a
 marginally-ready issue.
+
+## Mechanical pre-publish gate
+
+Before publishing a drafted `ready` **orphan, roadmap, or child** body
+(the shapes the linter supports — not the non-ready buckets below,
+which are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime is
+available. It mechanically re-checks a subset of the structural rules
+this contract states in prose — the autopilot-suitability marker's
+exactly-one/coherent-value rule, the one-directional check that a
+suitability score of `1` carries the configured `blocked-by-human`
+label (it does not check the reverse: a non-`1` score paired with the
+label still passes), markerPrefix consistency across every authoring
+marker, the declared shape's required section headings, the
+roadmap-id/blocked-by dependency-marker rules, and visible/hidden line
+agreement for the suitability and effort footers — so a weak model does
+not have to hold every rule in its head at once while drafting.
+
+The linter also emits one **advisory, warning-severity-only** finding
+(`prose-dependency`): it flags an issue/PR reference (`#<digits>` or a
+full GitHub issue/PR URL) that appears near coordination language (for
+example "before", "after", "once", "until", "predates", "gate"/"gated",
+"requires", "lands first") with no corresponding encoding for that
+reference as one of the three recognized forms: a `Blocked by #NNN`
+line, a `Depends on #NNN` line, or a task-list checkbox item
+(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
+`extractDependencyIssueNumbers` already recognize elsewhere in this
+contract. A task-list checkbox counts regardless of which heading it
+sits under, so a roadmap's own `## Tracks` membership list already
+satisfies this — it is not a separate "dependency-only" list. This
+catches the pattern this contract's own
+[Hidden human-dependency validation](#hidden-human-dependency-validation)
+check 4 warns about in prose — a hard precondition stated only in
+narrative text, not encoded as a real dependency marker. A full-URL
+reference is inherently local only when it actually names the current
+repository, since a cross-repo dependency cannot be encoded with these
+repository-local markers at all — flagging it would recommend an
+impossible fix. When the caller supplies the current `owner/repo`
+(`--current-repo`, defaulting to `$GITHUB_REPOSITORY` in CI), a
+full-URL reference naming a different repository is never flagged;
+without that context, a full-URL reference is still flagged by
+default (unchanged behavior) — unless its issue/PR number happens to
+already appear as a local `Blocked by` / `Depends on` / task-list
+marker elsewhere in the body, in which case it is treated as already
+encoded like any other match. A Markdown link's target may carry
+trailing content after the issue/PR number and before the link's
+closing paren — a URL fragment (`#issuecomment-123`), a trailing `/`,
+or a quoted link title (`"..."` or `'...'`) — and the link is still
+recognized as one match; without this, the label's own bare `#NNN`
+would otherwise leak through to the bare-`#` check and be misjudged
+independently of the link's (possibly cross-repo) target. A local
+`owner/repo#N` shorthand (e.g. `kurone-kito/idd-skill#4321`) is also
+recognized, but with the reverse default from the full-URL case above:
+it is flagged only when `--current-repo` is supplied **and**
+case-insensitively matches `owner/repo`; naming a different repository,
+or omitting `--current-repo`, always excludes it, since this shorthand
+was never recognized at all before and a bare `owner/repo` cannot be
+assumed local without confirmation. A reference-style Markdown link
+(`[text][ref]` with a separate `[ref]: target` definition elsewhere in
+the body) is recognized the same way as the inline-link form above,
+including the same `currentRepo`-based local/cross-repo comparison; a
+`ref` with no matching definition is left as literal text and falls
+through to the bare-`#` check like any other unrecognized shape. A
+quoted link title may contain a backslash-escaped quote matching its own
+delimiter (`\"` inside a `"..."` title, or `\'` inside a `'...'` title)
+without ending the title early and losing the rest of the link. An empty
+or whitespace-only `--current-repo` (or `$GITHUB_REPOSITORY`) is treated
+the same as omitting it entirely, rather than as a known repository that
+can never match. A nested/child list item's reference is evaluated
+together with its full ancestor chain's coordination-language text
+instead of being scoped away from it, while a sibling bullet at the same
+indentation — nested or top-level — still starts its own separate scope,
+preserving the tight-list sentence-conflation fix mentioned above. This
+holds for every nested child under a given parent, at any depth — not
+only the first. A continuation line resuming at an ancestor's own
+indentation, after a deeper child has already opened, is attributed to
+that ancestor rather than the deepest open child. A loose list (a blank
+line between sibling items) preserves the same ancestor scope across
+the blank line, as long as the following item's own marker is no deeper
+than whatever is still open at the end of the preceding item — a
+same-depth sibling, or a resumption at a shallower ancestor's own
+level — and the preceding item ends in a list marker rather than
+trailing plain prose (once plain prose follows the last marker, the
+list reads as already having ended, so the blank line is not bridged).
+A blank line directly followed by a more deeply indented marker is also
+not bridged, to avoid grafting an unrelated item onto an open ancestor
+as a false child. Unlike every other check above, a
+`prose-dependency` warning never flips `passed` to `false` and never
+changes the linter's exit code: it prompts the author to either
+convert the prose into a proper dependency marker or consciously
+confirm the reference is a mere breadcrumb.
+
+```sh
+node scripts/audit-authored-issue.mjs --shape <orphan|roadmap|child> \
+  --marker-prefix <resolved-target-prefix> \
+  --body-file <path-to-drafted-body> [--label <label>]...
+```
+
+Or, for npx/package-manager profiles, the equivalent
+`idd-audit-authored-issue` command. Pass `--stdin` instead of
+`--body-file` when the drafted body is not yet written to disk.
+**Always pass `--marker-prefix`** with the prefix resolved under
+[Target marker prefix](#target-marker-prefix): without it, the linter
+falls back to reading `.github/idd/config.json` from the current
+working directory, and if that file is missing or unreadable — for
+example when running from an installed bundle without a local
+checkout of the target repository's config — it silently defaults to
+this source repository's own `idd-skill` prefix, which produces a
+false pass or fail against the wrong prefix instead of an error.
+
+**No helper runtime available (`instructions-only` profile).** The
+linter cannot run without Node.js and the vendored `scripts/`
+directory, and an `instructions-only` install is a first-class
+supported fallback, not a degraded one. Unavailability is never a
+waiver: manually re-verify the same checks listed above against this
+contract's prose and the [Draft schemas](#required-draft-content)
+before publishing.
+
+A `passed: false` report (or non-zero exit, or a failed manual
+re-verification) means the draft is not ready to publish yet,
+regardless of how complete the narrative reads — fix every reported
+finding and re-run before treating the issue as `ready`. The linter (or
+its manual equivalent) is a mechanical structural check, not a
+substitute for the judgment-based checks above (human-dependency
+isolation, codebase fidelity, reuse-first) — passing it is necessary,
+not sufficient, for `ready`.
+
+## Autopilot-suitability score
+
+> **Status.** Active contract. Authoring **emits** the score footer
+> and Discover **ranks and routes** candidates by it (roadmap #759,
+> fully merged). The score stays advisory: it never bypasses the
+> A4.5/A5 gates and is fail-safe on absence.
+
+Authored issues carry a persisted **autopilot-suitability score**
+from 1 to 5 (higher = more autopilot-suitable). It is the durable,
+graded form of the **Autonomous completion** execution axis: the
+author makes the judgment once, while context is fresh, so the
+Discover phase can rank and route candidates by a cheap read
+instead of re-deriving autonomy per candidate.
+
+| Score | Meaning                     | Typical signals                                                                                                          |
+| ----- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| 5     | Autopilot-ideal             | Fully specified; deterministic verification (tests/lint/CI/mechanical); no external systems; no human judgment; isolated |
+| 4     | Strongly autopilot-suitable | Well-specified and verifiable; minor ambiguity resolvable from repo context; no external/human dependency                |
+| 3     | Borderline / mixed          | Autopilot can likely finish but with notable judgment, weaker verification, or review-attention risk                     |
+| 2     | Mostly human                | Agent may draft a partial result; completion needs human judgment, an asset, or review the agent cannot supply           |
+| 1     | Human-only                  | Interactive credentials, real deployment, subjective/design/product judgment, or external coordination                   |
+
+Scores below the configured discovery floor
+(`autopilotSuitability.floor`, default `3`) designate
+**human-oriented issues**: in autopilot runs Discover routes them
+to humans rather than autopilot.
+
+The score is recorded as a **footer at the end of the issue
+body** — a visible line paired with a hidden, prefix-aware
+machine marker, mirroring the `claimed-by` convention (visible
+note + HTML marker):
+
+```text
+---
+
+_Autopilot suitability: N / 5 -- higher is more autopilot-suitable;
+below the configured floor is human-oriented._
+
+<!-- {marker-prefix}-autopilot-suitability: N -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware via
+  `createMarkerRegex(markerPrefix, "autopilot-suitability")` exactly
+  as `roadmap-id` / `blocked-by` are. `N` is an integer 1-5. The
+  visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** This is body
+  content like `roadmap-id`; it must never be added to
+  `OPERATIONAL_MARKERS` in `scripts/protocol-helpers.mjs` or
+  subjected to F4 minimization.
+- **One source of truth.** A score of `1` must agree with
+  `status:blocked-by-human`; never publish a contradiction.
+- **Advisory, never a gate.** The score only ranks/routes
+  candidates. The A4.5 suitability gate and A5 claim safety checks
+  still run unchanged on whatever issue is selected; a high score
+  never bypasses a gate.
+- **Fail-safe on absence.** A missing, non-integer, or
+  out-of-range marker means "no score": Discover evaluates the
+  issue the normal way and never skips it. Pre-existing issues
+  with no score keep flowing.
+
+Backfill is opportunistic: when an existing open issue without a
+score footer is next edited by the authoring flow, add one. No
+bulk backfill of the existing backlog is required. The claim-state
+precondition still applies — never add the footer to the body of an
+actively-claimed or open-PR issue; defer it to a follow-up instead.
+
+## Effort hint
+
+Authored issues may also carry an **effort hint** — an author-time
+`S | M | L` size estimate, recorded once while context is fresh, that
+Discover consumes as a **soft selection tie-breaker** so autopilot tends
+to clear small issues first and leave large ones for a fresh session.
+Effort is distinct from the autopilot-suitability score: suitability
+captures _autonomy_ (can an agent finish unattended), while effort
+captures _size_ (a fully-autonomous issue can still be large).
+
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
+
+The hint is recorded as a **footer at the end of the issue body** — a
+visible line paired with a hidden, prefix-aware machine marker, beside
+the autopilot-suitability footer:
+
+```text
+---
+
+_Effort: S | M | L -- author-estimated size; a soft autopilot
+selection tie-breaker only._
+
+<!-- {marker-prefix}-effort: S|M|L -->
+```
+
+Binding rules:
+
+- **Authoritative value = the HTML marker**, read prefix-aware exactly
+  as `autopilot-suitability` is. `S | M | L` is upper-cased on parse.
+  The visible line is a human-readable mirror authoring keeps in sync;
+  discovery parses only the marker.
+- **Authoring marker, not operational marker.** Like
+  `autopilot-suitability`, it is body content and must never be added to
+  `OPERATIONAL_MARKERS` or subjected to F4 minimization.
+- **Soft tie-breaker, never a gate.** Effort only reorders candidates
+  **within** a single suitability-score band, after the score and
+  optional desync rules and **before** the lowest-issue-number tie-break.
+  It never skips, gates, crosses a score band, or bypasses the A4.5/A5
+  gates, and a large (`L`) issue stays fully claimable when it is the only
+  ready work.
+- **Fail-safe on absence.** A missing, non-`S|M|L`, or conflicting
+  marker means "no effort hint": selection behaves exactly as it does
+  today (a missing hint sorts as the neutral middle, as-if `M`).
+  Pre-existing issues with no effort footer keep flowing.
+
+Backfill is opportunistic and follows the same claim-state precondition
+as the suitability footer.
 
 ## Publication boundary
 

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -42,6 +42,25 @@ sequencing, parallel tracks, or multi-session handoff.
 Draft only stable non-ready buckets when the work still depends on a
 human decision, missing asset, or unclear verification.
 
+## Under-clarification stop rule
+
+Before drafting a `ready` issue, confirm you can name a concrete surface
+to edit and an objective verification for it. If, after bounded
+clarification, you still cannot, route the candidate to `needs-decision`
+or ask — do not publish a confidently-vague `ready` issue. Reliability
+over speed.
+
+This is an Intake-phase gate on your own confidence, not a wording
+judgment on an already-written draft — it is distinct from the
+"Under-specified" band in the next section, which assesses a body that
+has already been drafted.
+
+**Example**: "Improve the error handling in the API layer" fails this
+check — no concrete surface, no objective verification — even before
+you consider how detailed to write the body. Ask which endpoint or
+module, and what the observable failure mode is, or route the request
+to `needs-decision` instead of guessing at a plausible-sounding scope.
+
 ## Specificity target
 
 Execution-ready issue drafts should land in a middle band:
@@ -77,6 +96,48 @@ Before you publish a ready issue, confirm:
   while adding more detail would start turning it into a lightweight
   model script
 
+## Mechanical pre-publish gate
+
+Before you publish a drafted **ready orphan, roadmap, or child** body
+(scoped to those ready shapes — non-ready buckets like
+`blocked-by-human` are not audited by this gate), run the
+`audit-authored-issue` linter against it when a helper runtime
+is available. It mechanically catches shape and marker mistakes — a
+missing or duplicated autopilot-suitability footer, a wrong
+markerPrefix, a missing required heading for the declared shape, a
+malformed dependency marker — that a confident narrative can otherwise
+mask:
+
+```sh
+node scripts/audit-authored-issue.mjs --shape orphan \
+  --marker-prefix <resolved-target-prefix> --body-file draft.md
+```
+
+**Always pass `--marker-prefix`** with the prefix resolved under
+[contract.md's Target marker prefix](contract.md#target-marker-prefix):
+without it, the linter falls back to reading
+`.github/idd/config.json` from the current working directory, and
+silently defaults to this source repository's own `idd-skill` prefix
+when that file is missing or unreadable — producing a false pass or
+fail against the wrong prefix instead of an error.
+
+Use `--shape roadmap` or `--shape child` for those shapes, `--stdin`
+instead of `--body-file` when the draft is not yet on disk, and
+`--label <name>` (repeatable) to pass proposed labels for the check
+that a suitability score of `1` carries the configured
+`blocked-by-human` label (default `status:blocked-by-human`; use
+`--config <path>` to point at a policy that overrides the label name —
+this check is also one-directional, it does not flag the reverse, a
+non-`1` score paired with the label). Fix every reported finding and
+re-run before publishing; a `passed: false` report means the draft is
+not ready yet, regardless of how complete the narrative reads.
+
+**No helper runtime available (`instructions-only` profile):** the
+linter cannot run. `instructions-only` is a first-class supported
+fallback, not a waiver — manually re-verify the same checks against
+[contract.md's Mechanical pre-publish gate](contract.md#mechanical-pre-publish-gate)
+before publishing instead.
+
 ## Hidden human-dependency quick check
 
 Before you publish a `ready` issue, confirm:
@@ -92,18 +153,31 @@ Before you publish a `ready` issue, confirm:
 - dependency markers represent true start blockers rather than grouping
   related work
 
+## Codebase-fidelity quick check
+
+Before you publish a `ready` issue, confirm:
+
+- when the issue reuses an existing identifier or field name, the
+  specified value matches that name's established semantics in the
+  codebase — it does not overload a name with a new shape or source
+- values that are mutable at runtime are flagged to specify a live read
+  at the point of use rather than a one-time capture at construction
+
 ## Example orphan issue
 
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional `## Candidate files`
+- an autopilot-suitability footer at the end of the body (visible
+  line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 
 Use this shape when the work is narrow enough to pass the IDD viability
 gate on its own and the target repository can actually discover orphan
-issues. If the repository keeps the default `issue-scope: roadmap`,
-prefer a one-item roadmap package instead of publishing a standalone
-orphan issue.
+issues (`issue-scope: roadmap-first`, the default, via the orphan
+fallback, or `orphan-first`). If the repository sets
+`issue-scope: roadmap` (roadmap-only), prefer a one-item roadmap package
+instead of publishing a standalone orphan issue.
 
 ## Example roadmap package
 
@@ -114,6 +188,7 @@ Roadmap issue:
 - `## Tracks`
 - `## Success criteria`
 - one `<!-- <marker-prefix>-roadmap-id: ... -->` marker
+- an autopilot-suitability footer at the end of the body
 
 Child issue:
 
@@ -122,6 +197,7 @@ Child issue:
 - `## Proposed change`
 - `## Acceptance criteria`
 - optional dependency line or sequential roadmap marker when needed
+- an autopilot-suitability footer at the end of the body
 
 Keep ready child issues in the roadmap task list rather than grouping
 them with hidden dependency markers.
@@ -197,9 +273,48 @@ This is an artificial split when the three edits form one natural,
 cohesive authoring change. Do not break a single reviewable task into
 multiple sibling issues only to widen parallel execution.
 
-Resolve `<marker-prefix>` from the target repository's onboarding or IDD
-docs before publishing the draft. Use `idd-skill` only when the target
-repository actually configured that prefix.
+### Finalize or verify track that asserts sibling-produced state
+
+Anti-pattern — prose sequencing only:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+
+_Runs after the wiring tracks #441-#445._
+```
+
+The hard `Blocked by #440` names only the build foundation, and the
+after-the-siblings ordering lives in prose. Once `#440` closes, Discover
+reports `#450` startable and A4.5 passes it (Actionability inspects the body,
+not completability) — but its acceptance criteria assert state that only the
+unmerged `#441`–`#445` produce, so claiming it means failing acceptance or
+doing the siblings' work.
+
+Correct — encode `Blocked by` on each sibling whose output the acceptance
+criteria depend on:
+
+```md
+#450 — finalize the config, reconcile the docs, verify the combined result
+
+Blocked by #440
+Blocked by #441
+Blocked by #442
+Blocked by #443
+Blocked by #444
+Blocked by #445
+```
+
+Now Discover and A4.5 defer `#450` until every sibling merges, so it is
+claimed only when its acceptance criteria can actually pass.
+
+**Prefix-first**: resolve `<marker-prefix>` from the target repository's
+onboarding or IDD docs before emitting any of these markers —
+`roadmap-id`, `blocked-by`, `autopilot-suitability`, or `effort` — not
+just the dependency markers shown above. Never default to `idd-skill`
+in an installed bundle; use it only when the target repository actually
+configured that prefix.
 
 ## Human-dependency isolation examples
 
@@ -374,6 +489,13 @@ not yet ready. Move that criterion to a `blocked-by-human` or
 what the agent can verify independently.
 
 ## Handling duplicates and non-ready outcomes
+
+One source of follow-up issue candidates is the read-only
+`merged-pr-feedback-sweep` helper's JSON output — the unresolved review
+threads and undispositioned advisory feedback it detects on merged PRs.
+Treat each entry as a candidate only: re-verify it against current `main`
+with the reuse-first tree below before drafting, because the feedback may
+already be addressed.
 
 Before publishing an issue, apply a reuse-first decision tree:
 

--- a/.claude/skills/issue-authoring/references/workflow-boundary.md
+++ b/.claude/skills/issue-authoring/references/workflow-boundary.md
@@ -26,8 +26,10 @@ The issue-authoring bundle fits into a three-phase handoff:
 - For new issues, bundled skill creates the issue with the authoring label
   when the publication command supports that; otherwise it applies the
   label immediately after creation
-- If post-create label application fails, bundled skill closes, deletes,
-  or otherwise makes the created issue undiscoverable before stopping
+- If post-create label application fails, bundled skill closes the created
+  issue before stopping; deletion needs admin permission the authoring
+  agent typically lacks (and `docs/permissions.md` forbids for normal IDD),
+  so it is not the default path
 - User verifies the published issues look correct
 - Bundled skill removes the authoring label from all published issues only
   after the full issue set is published, the user confirms the result, and
@@ -66,9 +68,10 @@ assumptions that did not hold when published may fail A4.5 checks
 waste agent time during work.
 
 **Prevention during drafting**: This bundle is where coherence, safety,
-and uniqueness should be validated **before** publishing. The three
-A4.5 prevention checks (coherence, safety, uniqueness) correspond to
-bucket escalation triggers during drafting:
+and uniqueness should be validated **before** publishing. A4.5 runs
+seven suitability checks; the three that drafting can most directly
+prevent (coherence, safety, uniqueness) correspond to bucket escalation
+triggers during drafting:
 
 - If an issue might be incoherent → escalate to `needs-decision` during
   drafting
@@ -83,8 +86,9 @@ time and report the specific failure (unclear, invalid, duplicate).
 
 ## Use this bundle to
 
-- prepare IDD-ready orphan issues when the target repository supports
-  `issue-scope: orphan-first`, including any required
+- prepare IDD-ready orphan issues when the target repository discovers
+  orphans (`issue-scope: roadmap-first`, the default, via the orphan
+  fallback, or `orphan-first`), including any required
   `orphan-first-policy` approval handoff
 - prepare roadmap packages and child issues when work needs visible
   sequencing or parallel tracks

--- a/.github/ISSUE_TEMPLATE/idd-task.yml
+++ b/.github/ISSUE_TEMPLATE/idd-task.yml
@@ -23,6 +23,13 @@ body:
         `issue-authoring` skill first and surface the unresolved part
         as a separate `needs-decision` / `blocked-by-human` issue.
 
+        **Editing an already-claimed issue?** Check whether this issue
+        has an active claim (a recent `claimed-by` comment) or an open
+        PR before editing its body. A working agent snapshots the body
+        into its plan and never re-reads it, so a post-claim body edit
+        is silently lost. Post a comment instead, and cover the change
+        with a follow-up issue if it needs to happen.
+
   - type: input
     id: parent
     attributes:
@@ -74,3 +81,23 @@ body:
     attributes:
       label: Notes
       description: 'Optional. Sequencing, parallelism hints, links to upstream context, or anything else a future claimer should know.'
+
+  - type: textarea
+    id: autopilot_suitability
+    attributes:
+      label: Autopilot suitability
+      description: 'Required footer for the IDD discover phase. Score 1 (human-only) to 5 (autopilot-ideal); scores below the configured floor route to a human instead of autopilot. Enter the visible line and the hidden marker exactly as shown.'
+      placeholder: |
+        Autopilot suitability: 4/5 — {why this score}.
+
+        <!-- dotfiles-autopilot-suitability: 4 -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: effort
+    attributes:
+      label: Effort (optional)
+      description: 'Optional soft tie-breaker for Discover candidate selection. S/M/L, fail-safe on absence.'
+      placeholder: |
+        <!-- dotfiles-effort: S -->

--- a/.github/ISSUE_TEMPLATE/idd-task.yml
+++ b/.github/ISSUE_TEMPLATE/idd-task.yml
@@ -88,7 +88,10 @@ body:
       label: Autopilot suitability
       description: 'Required footer for the IDD discover phase. Score 1 (human-only) to 5 (autopilot-ideal); scores below the configured floor route to a human instead of autopilot. Enter the visible line and the hidden marker exactly as shown.'
       placeholder: |
-        Autopilot suitability: 4/5 — {why this score}.
+        ---
+
+        _Autopilot suitability: 4 / 5 -- higher is more autopilot-suitable;
+        below the configured floor is human-oriented._
 
         <!-- dotfiles-autopilot-suitability: 4 -->
     validations:
@@ -100,4 +103,7 @@ body:
       label: Effort (optional)
       description: 'Optional soft tie-breaker for Discover candidate selection. S/M/L, fail-safe on absence.'
       placeholder: |
+        _Effort: S -- author-estimated size; a soft autopilot selection
+        tie-breaker only._
+
         <!-- dotfiles-effort: S -->


### PR DESCRIPTION
## Summary

Closes #147.

Re-fetches the 5-file `issue-authoring` bundle from `kurone-kito/idd-skill`'s
pinned commit `4e8c7043edcb00dd8447dee83e7a17e5b2604d5d`
(`skills/issue-authoring/`), replacing this repo's stale content that
was still pinned to the original `b64eab0` import (#97).

- Re-applies both documented local modifications on the new content:
  `SKILL.md`'s Reference Routing installed-bundle note and
  `references/contract.md`'s Target marker prefix override, both
  repinned to `4e8c704` and marked with
  `<!-- dotfiles-divergence: installed-bundle-reference-routing -->`.
- `references/draft-patterns.md` and `references/workflow-boundary.md`
  carry no local modifications, so they copy over unmarked.
- Aligns `.github/ISSUE_TEMPLATE/idd-task.yml` with the 0.4.0 authoring
  contract: a required autopilot-suitability footer field, an optional
  effort footer field, and a claim-state precondition note against
  editing actively-claimed issue bodies.

## Test plan

- [x] `diff -ru` between `.claude/skills/issue-authoring/` and the
      pinned upstream `skills/issue-authoring/` shows only the two
      documented local modifications
- [x] No `b64eab0` or `4103665` reference remains under `.claude/skills/`
- [x] `npx markdownlint-cli2 "**/*.md"` — 0 issues
- [x] `npx cspell` on touched files — 0 issues
- [x] `idd-task.yml` parses as valid YAML (`npx js-yaml`) with the
      expected field set including the new autopilot-suitability and
      effort fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dz1GQ6a5w3RPxbU1mxsdP1