### PR TITLE
feat(idd): adopt 0.4.0 policy keys, default label taxonomy, and refresh idd-policy.md

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -12,6 +12,13 @@
   "trustedMarkerActors": [
     "kurone-kito"
   ],
+  "advisoryBotLogins": [
+    "copilot-pull-request-reviewer[bot]",
+    "coderabbitai[bot]"
+  ],
+  "workshop": {
+    "exampleRepository": ""
+  },
   "commands": {
     "install-deps": "git submodule update --init --recursive",
     "fix-validate": "npx markdownlint-cli2 --fix && npx markdownlint-cli2",
@@ -21,13 +28,29 @@
   "helperRuntime": {
     "profile": "ephemeral-npx"
   },
-  "issueScope": "roadmap",
+  "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "ciWait": {
     "runningTimeout": "PT10M",
     "generationTimeout": "PT10M",
     "rerunPolicy": "rerun-once"
   },
+  "ciGate": {
+    "externalChecks": {
+      "waivable": [
+        { "selector": "idd-advisory-convergence" }
+      ]
+    },
+    "externalCheckWaivers": {
+      "mode": "maintainer-authorized"
+    }
+  },
   "skipIssueAuthorApprovalGate": true,
-  "maintainerApprovalActorPolicy": "owners-and-maintainers-only"
+  "maintainerApprovalActorPolicy": "owners-and-maintainers-only",
+  "autopilotSuitability": {
+    "floor": 3
+  },
+  "worktreeGuard": {
+    "enabled": true
+  }
 }

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -156,11 +156,14 @@ for the readiness buckets, output chooser, and approval boundary.
 **Policy**: `roadmap-first` (migrated from `roadmap`, confirmed by
 roadmap #144).
 
-Discovery prefers roadmap-linked candidates but falls back to orphan
-discovery (A0-O) when none are ready. **`orphanFirstPolicy`**: `none`
-(distributed default) — the orphan fallback path stays disabled
-outright, so `roadmap-first` currently behaves like `roadmap` in
-practice until this policy is deliberately loosened.
+`roadmap-first`'s upstream-documented semantics prefer roadmap-linked
+candidates and fall back to orphan discovery (A0-O) when none are
+ready — but this repository's **`orphanFirstPolicy`** stays `none`
+(distributed default), which disables the orphan fallback path
+outright. In this repository, no orphan-discovery fallback runs;
+`roadmap-first` behaves identically to `roadmap` until
+`orphanFirstPolicy` is deliberately loosened to
+`maintainer-approved` or `public-disabled`.
 
 ## Worktree Guard
 
@@ -236,9 +239,11 @@ Confirmed at their distributed defaults rather than given an explicit
 ## Divergence Register
 
 Every intentional deviation from the pinned upstream template carries
-a `<!-- dotfiles-divergence: <slug> -->` marker at its point of use, so
-a future re-import can detect and preserve it instead of silently
-reverting to upstream's default. Current slugs:
+a `dotfiles-divergence: <slug>` marker at its point of use -- an HTML
+comment (`<!-- ... -->`) in Markdown/YAML/instruction files, a line
+comment (`// ...`) in JavaScript -- so a future re-import can detect
+and preserve it instead of silently reverting to upstream's default.
+Current slugs:
 
 | Slug                                 | What it marks                                                                                                                                                                                        | Introduced by |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -3,15 +3,22 @@
 This repository uses the Issue-Driven Development (IDD) workflow
 imported from
 [`kurone-kito/idd-skill`](https://github.com/kurone-kito/idd-skill).
-This page records the eleven policy decisions confirmed during the
-onboarding flow (roadmap #95). The machine-readable mirror lives at
+This page records the policy decisions confirmed during the
+onboarding flow (roadmap #95) and the 0.4.0 re-import (roadmap #144).
+The machine-readable mirror lives at
 [`.github/idd/config.json`](../.github/idd/config.json); keep both in
 sync when the policy changes.
 
 The schema name for each field below comes from the upstream
-[`idd-template/docs/onboarding/policy-decisions.md`](https://github.com/kurone-kito/idd-skill/blob/b64eab0d51a79bd3199740505f3b7843bc94a0d4/idd-template/docs/onboarding/policy-decisions.md)
+[`idd-template/docs/onboarding/policy-decisions.md`](https://github.com/kurone-kito/idd-skill/blob/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d/idd-template/docs/onboarding/policy-decisions.md)
 so future IDD sessions can navigate between the human-readable record
 and the upstream template without surprises.
+
+**Pinned upstream commit**: `4e8c7043edcb00dd8447dee83e7a17e5b2604d5d`
+(abbreviated `4e8c704`; `git describe`: `v0.4.0-1242-g4e8c7043`),
+imported by roadmap #144. `iddVersion` in
+[`.github/idd/config.json`](../.github/idd/config.json) is bumped
+separately, by #150's final verification sweep.
 
 ## Merge Policy
 
@@ -96,7 +103,7 @@ The discover, suitability, review-snapshot, advisory-wait, and
 pre-merge phases may invoke the helper manifest via:
 
 ```sh
-npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/b64eab0d51a79bd3199740505f3b7843bc94a0d4 \
+npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
   idd-helper-bundle-manifest --profile ephemeral-npx
 ```
 
@@ -144,6 +151,105 @@ Discover loop starts. See its
 [bundled contract](../.claude/skills/issue-authoring/references/contract.md)
 for the readiness buckets, output chooser, and approval boundary.
 
+## Issue Scope
+
+**Policy**: `roadmap-first` (migrated from `roadmap`, confirmed by
+roadmap #144).
+
+Discovery prefers roadmap-linked candidates but falls back to orphan
+discovery (A0-O) when none are ready. **`orphanFirstPolicy`**: `none`
+(distributed default) — the orphan fallback path stays disabled
+outright, so `roadmap-first` currently behaves like `roadmap` in
+practice until this policy is deliberately loosened.
+
+## Worktree Guard
+
+**`worktreeGuard.enabled`**: `true`. **`worktreeGuard.branchPatterns`**:
+not set (distributed default `["issue/*", "roadmap-audit/*"]`).
+
+Enabling this flag alone has no effect until its enforcement consumers
+(idd-doctor --strict, the optional `core.hooksPath` hook) are wired up
+— that is roadmap #144's #148. `.githooks/` was imported inert by #196.
+
+## Advisory Bot Logins
+
+**`advisoryBotLogins`**: `["copilot-pull-request-reviewer[bot]",
+"coderabbitai[bot]"]`.
+
+Both logins were confirmed against live review events on
+[PR #193](https://github.com/kurone-kito/dotfiles/pull/193), which
+carries review activity from both bots. Settle/wait
+([`idd-advisory-wait.instructions.md`](../.github/instructions/idd-advisory-wait.instructions.md))
+stays Copilot-only regardless of this list — **`advisoryWait.primaryBotLogin`**
+and **`advisoryWait.secondaryBotLogin`** are left unset, so CodeRabbit
+reviews are dispositioned on arrival via this list but never gate the
+advisory-wait clock.
+
+## Autopilot Suitability
+
+**`autopilotSuitability.floor`**: `3` (explicit default; `enabled` left
+unset, default `true`).
+
+Discovery considers issues whose authored autopilot-suitability score
+is `>= 3`; lower-scored candidates route to a human. Advisory
+ranking/routing hint only — never bypasses the A4.5/A5 safety gates.
+
+## Workshop Example Repository
+
+**`workshop.exampleRepository`**: `""` (distributed default — disables
+the `idd-doctor` cross-check that expects an example repository's
+README to back-link to `docs/workshop/`; this repository has no such
+directory).
+
+## CI Gate External Check Waivers
+
+**`ciGate.externalCheckWaivers.mode`**: `maintainer-authorized`.
+**`ciGate.externalChecks.waivable`**: `[{ "selector":
+"idd-advisory-convergence" }]`. **`authorityPolicy`** and
+**`maxValidity`** are left unset (distributed defaults
+`owners-and-maintainers-only` and `PT24H`).
+
+This prepares the waiver path for roadmap #144's #149 (hosting the
+`idd-advisory-convergence` workflow as a required status check) and is
+harmless while that check does not yet exist — no selector currently
+matches anything, so no waiver can be issued or consumed.
+
+## New 0.4.0 Schema Keys Left at Default
+
+Confirmed at their distributed defaults rather than given an explicit
+`.github/idd/config.json` entry (roadmap #144):
+
+- **`advisoryWait.convergenceScope`**: `all-prs`
+- **`advisoryWait.sameHeadRerollCap`**: `2`
+- **`advisoryWait.recoveryCycleCap`**: `2`
+- **`advisoryWait.terminalWindow`**: `PT12H`
+- **`ciGate.trustEmptyProtectionReads`**: `false`
+- **`mergeGate.soloCodeownerAdminFallback`**: `auto-admin-retry` — this
+  repository is solo-maintainer (`trustedMarkerActors: ["kurone-kito"]`
+  only) with `mergePolicy: fully_autonomous_merge`, exactly the
+  topology this key governs, and the distributed default (F3 retries
+  once with `gh pr merge --admin` when the sole blocker is the
+  solo-CODEOWNER self-approval deadlock) matches this repository's
+  existing autonomous-merge intent. Recorded here as a deliberate
+  confirmation, not an oversight.
+
+## Divergence Register
+
+Every intentional deviation from the pinned upstream template carries
+a `<!-- dotfiles-divergence: <slug> -->` marker at its point of use, so
+a future re-import can detect and preserve it instead of silently
+reverting to upstream's default. Current slugs:
+
+| Slug                                 | What it marks                                                                                                                                                                                        | Introduced by |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `claim-timing`                       | The `12h`/`6h` claim-stale-age/heartbeat-interval override, in place of the `24h`/`12h` distributed defaults                                                                                         | #145, #196    |
+| `helper-profile-ephemeral-npx`       | This repository's `ephemeral-npx` helper profile, where docs describe a different upstream-default profile inline                                                                                    | #196          |
+| `installed-bundle-reference-routing` | The issue-authoring companion's reference routing, adapted for an installed-bundle (not source-repo) stance                                                                                          | #147          |
+| `master-branch`                      | `master` in place of upstream's `main` as the integration branch name                                                                                                                                | #145, #196    |
+| `onboarding-doc-trim`                | The deliberate exclusion of `docs/onboarding/placeholders.md` and `docs/onboarding/policy-decisions.md` (self-corrupt after placeholder substitution), linking to the pinned upstream copies instead | #145, #196    |
+| `signing-ladder`                     | The GPG -> SSH -> unsigned commit-signing fallback ladder, a dotfiles-specific addition with no upstream equivalent                                                                                  | #145          |
+| `vendored-file-header`               | The corrected header on `scripts/minimize-superseded-markers.mjs`, since this repository has no build step to regenerate it from a TypeScript source                                                 | #196          |
+
 ## Open follow-ups
 
 The remaining work after onboarding lives in two roadmaps. The
@@ -187,6 +293,12 @@ exercised today because the issue-author approval gate is opted out
 would activate the labels without needing new repository state.
 [`.github/ISSUE_TEMPLATE/idd-task.yml`](../.github/ISSUE_TEMPLATE/idd-task.yml)
 ships the structured form for hand-filed IDD tasks.
+
+Roadmap #144 additionally confirmed the 0.4.0 default label taxonomy:
+`roadmap` (already existed), `status:blocked-by-human`, and
+`status:needs-decision` (both created by #146). `.github/idd/config.json`
+does not set `labels.*`, since all three use the schema's distributed
+default names.
 
 ### PR review profile
 


### PR DESCRIPTION
## Summary

Configure the 0.4.0 policy keys confirmed by roadmap #144, now that
#145 and #196 have re-imported the instruction/docs surface those
decisions depend on.

`.github/idd/config.json`:
- `issueScope: "roadmap-first"` (migrated from `"roadmap"`), matching
  what `idd-overview-core.instructions.md`'s Project commands table
  already declared.
- `worktreeGuard.enabled: true` (`branchPatterns` left at its
  default; enforcement stays inert until #148 wires
  `core.hooksPath`).
- `advisoryBotLogins: ["copilot-pull-request-reviewer[bot]",
  "coderabbitai[bot]"]` -- confirmed live against PR #193's review
  events.
- `autopilotSuitability.floor: 3` and `workshop.exampleRepository: ""`
  (explicit defaults).
- `ciGate.externalCheckWaivers` (`maintainer-authorized`) +
  `externalChecks.waivable` for `idd-advisory-convergence`, preparing
  #149's required-check track; harmless while that check doesn't
  exist yet.

Every other new 0.4.0 schema key (`advisoryWait.convergenceScope`,
`sameHeadRerollCap`, `recoveryCycleCap`, `terminalWindow`,
`ciGate.trustEmptyProtectionReads`, `mergeGate.soloCodeownerAdminFallback`)
stays at its distributed default with no explicit config entry, each
recorded as a deliberate decision in `docs/idd-policy.md` rather than
silently left unset.

`docs/idd-policy.md`:
- New sections for each decision above.
- Bump both `b64eab0` references (policy-decisions link,
  helper-manifest npx pin) to the current pin `4e8c704`.
- New Divergence Register section enumerating the seven
  `dotfiles-divergence` marker slugs #145/#147/#196 introduced.
- Re-audit "Open follow-ups" against live ruleset state (still
  accurate -- four required checks unchanged) and note the two newly
  created labels.

Repository labels: created `status:blocked-by-human` and
`status:needs-decision` (`roadmap` already existed).

Closes #146.

## Test plan

- [x] `.github/idd/config.json` validates against the pinned upstream
      `schemas/policy.schema.json` via `npx ajv-cli validate --spec=draft2020`.
- [x] `advisoryBotLogins` entries confirmed against PR #193's live
      review events (`coderabbitai[bot]`, `copilot-pull-request-reviewer[bot]`).
- [x] `gh label list` shows `roadmap`, `status:blocked-by-human`,
      `status:needs-decision`; roadmap #144 carries `roadmap`.
- [x] `docs/idd-policy.md` contains no `b64eab0`/`4103665` reference.
- [x] `npx markdownlint-cli2 "**/*.md"` passes.
- [x] `tests/bash/helpers/bats-core/bin/bats tests/bash/` passes (6
      pre-existing local-environment failures in `60-mise.bats`,
      unrelated and unmodified by this PR).
- [x] `pwsh -c "Invoke-Pester tests/powershell/"` passes (5
      pre-existing local-environment failures, same class as above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented updated policy decisions and the pinned upstream reference.
  * Clarified issue-selection rules, worktree safeguards, advisory settings, automation thresholds, workshop repository handling, and CI waiver behavior.
  * Added a divergence register and recorded the default label taxonomy.

* **Configuration**
  * Added policy settings for advisory logins, workshop examples, CI checks, automation suitability, and worktree protection.
  * Updated issue scope to prioritize roadmap items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->