### PR TITLE
feat(idd): host the idd-advisory-convergence workflow as a required status check

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -56,6 +56,7 @@ words:
   - MINIMIZABLE
   - MYVIMRC
   - nnoremap
+  - nvmrc
   - onlogon
   - ONNX
   - psmux

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,0 +1,55 @@
+name: IDD advisory-convergence gate
+# Required-check workflow asserting Copilot advisory-review
+# convergence on a PR. Adapted from kurone-kito/idd-skill's
+# idd-template/.github/workflows/idd-advisory-convergence.yml at pin
+# 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d. Registered as a required
+# status check on `master` with the maintainer-authorized waiver
+# escape configured in `.github/idd/config.json` `ciGate.*`. See
+# docs/idd-policy.md "CI Gate External Check Waivers" for the waiver
+# path.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to re-check (e.g. after posting a maintainer waiver)
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+jobs:
+  idd-advisory-convergence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Trusted default-branch checkout, not the PR head, for any
+          # trigger type including workflow_dispatch: the assertion
+          # logic and its config (.github/idd/config.json) must be the
+          # trusted copy, not the PR's own -- otherwise a PR could edit
+          # the verdict logic itself to force `ready: true`. The
+          # verdict still correctly evaluates the intended PR: `--pr
+          # <number>` below drives every live GitHub API call
+          # independent of what is checked out locally.
+          # <!-- dotfiles-divergence: master-branch -->
+          ref: master
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      # This repository runs the ephemeral-npx helper profile (no
+      # vendored scripts/ directory), so invoke the packaged CLI
+      # rather than upstream's `node scripts/advisory-convergence.mjs`
+      # form. See docs/idd-policy.md "Helper Runtime Profile".
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+            idd-advisory-convergence --pr ${{ github.event.pull_request.number || inputs.pr_number }} --assert

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,12 +1,13 @@
 name: IDD advisory-convergence gate
-# Required-check workflow asserting Copilot advisory-review
-# convergence on a PR. Adapted from kurone-kito/idd-skill's
+# Asserts Copilot advisory-review convergence on a PR, intended to be
+# registered as a required status check on `master` (once this
+# workflow is proven green -- see #149). Adapted from
+# kurone-kito/idd-skill's
 # idd-template/.github/workflows/idd-advisory-convergence.yml at pin
-# 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d. Registered as a required
-# status check on `master` with the maintainer-authorized waiver
-# escape configured in `.github/idd/config.json` `ciGate.*`. See
-# docs/idd-policy.md "CI Gate External Check Waivers" for the waiver
-# path.
+# 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d. The maintainer-authorized
+# waiver escape is already configured in `.github/idd/config.json`
+# `ciGate.*`; see docs/idd-policy.md "CI Gate External Check Waivers"
+# for the waiver path.
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
## Summary

Copy `kurone-kito/idd-skill`'s
`idd-template/.github/workflows/idd-advisory-convergence.yml` at pin
`4e8c7043edcb00dd8447dee83e7a17e5b2604d5d` into
`.github/workflows/idd-advisory-convergence.yml`, adapted for this
repository:

- checkout `ref: master` (upstream's template uses `main`; marked
  `<!-- dotfiles-divergence: master-branch -->`).
- `actions/checkout@v7` and `actions/setup-node@v4` with
  `node-version-file: '.nvmrc'`, matching this repository's own
  action-version and Node-pin conventions (no other dotfiles workflow
  uses `setup-node` yet).
- `persist-credentials: false` -- this job only reads.
- Invoke the assertion via the pinned `ephemeral-npx` spec
  (`idd-advisory-convergence --pr <n> --assert`) instead of upstream's
  `node scripts/advisory-convergence.mjs` form, since this repository
  doesn't vendor `scripts/`.

Registered the job as a required status check on `master` (ruleset
`18861545`) after confirming this workflow ran green on this PR,
per the acceptance criteria's own ordering.

Closes #149.

## Test plan

- [x] Verified the `binName: idd-advisory-convergence` ->
      `entryPath: scripts/advisory-convergence.mjs` mapping against
      `scripts/helper-runtime-manifest.mjs` at the pinned commit
      before relying on it.
- [x] Ran the exact invocation
      (`npx --yes --package
      https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d
      idd-advisory-convergence --pr 217 --assert`) locally against a
      real (merged) PR before adding it to CI, confirming the CLI
      accepts this argument form and emits a well-formed JSON verdict.
- [x] `actionlint` (repo-wide) reports no findings.
- [x] `npx cspell` passes.
- [x] The workflow ran green on this PR once Copilot's review
      converged (initial runs correctly failed with `"reason":
      "copilot has not reviewed this pull request yet"`, then
      `"...does not cover current HEAD"` after a review-response
      push -- both expected, not bugs; re-ran via `gh run rerun`
      once Copilot's review covered the final HEAD and all threads
      were resolved).
- [x] The job is registered as a required status check on `master`:
      ```
      $ gh api repos/kurone-kito/dotfiles/rulesets/18861545 | jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
      [
        { "context": "lint" },
        { "context": "Lua syntax check" },
        { "context": "Bash tests (bats)" },
        { "context": "PowerShell tests (Pester)" },
        { "context": "idd-advisory-convergence" }
      ]
      ```
      Confirmed `gh pr view 219 --json mergeable,mergeStateStatus`
      still reports `MERGEABLE`/`CLEAN` immediately after the ruleset
      update -- no deadlock introduced.
- [x] Job id `idd-advisory-convergence` equals the
      `ciGate.externalCheckWaivers` waivable selector configured in
      #146.
- [x] No `4103665` reference remains in the workflow file.
