### PR TITLE
chore(idd): resolve idd-doctor's post-merge cleanup backlog finding

### DIFF
--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -316,7 +316,7 @@ five-check ruleset above is now that required set.
 ### `idd-doctor` findings
 
 A full `idd-doctor` run (pinned `ephemeral-npx` spec) now exits
-`result: passed` with five `WARN`s and no `ERROR`; each below is
+`result: passed` with four `WARN`s and no `ERROR`; each below is
 expected, not a defect. #218 resolved the one finding that was a
 genuine `ERROR` (the `idd-task.yml` placeholder syntax) by
 reformatting it; the remaining findings are accepted noise, recorded
@@ -343,12 +343,24 @@ rediscover them:
   distributed default `false` (fail-closed; confirmed deliberately in
   #146), so this surfaces as a warning rather than being silently
   treated as "no protection configured".
-- **Post-merge cleanup backlog** (34+ merged PRs lacking F4 cleanup
-  evidence): a new-since-the-original-pin check this repository has
-  not yet investigated or run against; applying its remediation
-  touches GitHub-visible state across many historical PRs, so it is
-  tracked as its own follow-up rather than run blind here. Tracked in
-  #220.
+Issue #220 investigated and resolved the **post-merge cleanup
+backlog** check (new since the roadmap's original pin): it flags
+merged PRs missing a `<!-- idd-cleanup-evidence: ... -->` comment,
+which requires running `idd-audit-pr-cleanup` and posting the marker
+regardless of whether the run finds anything to minimize -- a `clean`
+result (no candidates) still needs its own evidence comment, or the
+check keeps flagging the PR. The backlog existed because this
+repository's F4 step is a manual, agent-run part of the merge sequence
+with no server-side backstop, so most of this session's merges skipped
+it. #220 cleared the existing 35-PR backlog by running the pinned
+`ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue
+220 --claim-id <claim-id>` CLI against every flagged PR and posting
+the evidence comment by hand; `idd-doctor` now reports zero backlog
+PRs. This does not prevent regrowth on future merges that skip F4;
+issue #223 tracks adding the server-side `post-merge-cleanup.yml`
+workflow upstream ships for the `vendored-node` profile, adapted for
+`ephemeral-npx` the same way #149 adapted
+`idd-advisory-convergence.yml`.
 
 `.github/ISSUE_TEMPLATE/idd-task.yml`'s `proposed_change` and
 `acceptance_criteria` textarea placeholders formerly used

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -343,24 +343,24 @@ rediscover them:
   distributed default `false` (fail-closed; confirmed deliberately in
   #146), so this surfaces as a warning rather than being silently
   treated as "no protection configured".
-Issue #220 investigated and resolved the **post-merge cleanup
-backlog** check (new since the roadmap's original pin): it flags
-merged PRs missing a `<!-- idd-cleanup-evidence: ... -->` comment,
-which requires running `idd-audit-pr-cleanup` and posting the marker
-regardless of whether the run finds anything to minimize -- a `clean`
-result (no candidates) still needs its own evidence comment, or the
-check keeps flagging the PR. The backlog existed because this
-repository's F4 step is a manual, agent-run part of the merge sequence
-with no server-side backstop, so most of this session's merges skipped
-it. #220 cleared the existing 35-PR backlog by running the pinned
-`ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue
-220 --claim-id <claim-id>` CLI against every flagged PR and posting
-the evidence comment by hand; `idd-doctor` now reports zero backlog
-PRs. This does not prevent regrowth on future merges that skip F4;
-issue #223 tracks adding the server-side `post-merge-cleanup.yml`
-workflow upstream ships for the `vendored-node` profile, adapted for
-`ephemeral-npx` the same way #149 adapted
-`idd-advisory-convergence.yml`.
+- **Post-merge cleanup backlog** (new since the roadmap's original
+  pin, resolved by #220): the check flags merged PRs missing a
+  `<!-- idd-cleanup-evidence: ... -->` comment, which requires running
+  `idd-audit-pr-cleanup` and posting the marker regardless of whether
+  the run finds anything to minimize -- a `clean` result (no
+  candidates) still needs its own evidence comment, or the check keeps
+  flagging the PR. The backlog existed because this repository's F4
+  step is a manual, agent-run part of the merge sequence with no
+  server-side backstop, so most of this session's merges skipped it.
+  #220 cleared the existing 35-PR backlog by running the pinned
+  `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue
+  220 --claim-id <claim-id>` CLI against every flagged PR and posting
+  the evidence comment by hand; `idd-doctor` now reports zero backlog
+  PRs. This does not prevent regrowth on future merges that skip F4;
+  issue #223 tracks adding the server-side `post-merge-cleanup.yml`
+  workflow upstream ships for the `vendored-node` profile, adapted for
+  `ephemeral-npx` the same way #149 adapted
+  `idd-advisory-convergence.yml`.
 
 `.github/ISSUE_TEMPLATE/idd-task.yml`'s `proposed_change` and
 `acceptance_criteria` textarea placeholders formerly used


### PR DESCRIPTION
## Summary

- Cleared `idd-doctor`'s post-merge cleanup backlog finding: 35 merged PRs (in the last 14 days) lacked a `<!-- idd-cleanup-evidence: ... -->` comment. Ran the pinned `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue 220 --claim-id <claim-id>` CLI against every flagged PR and posted the evidence comment; `idd-doctor` now reports zero backlog PRs.
- Updated `docs/idd-policy.md`'s `idd-doctor` findings section to record why the backlog existed (this repository's F4 comment-cleanup step is manual with no server-side backstop, so most of this session's merges skipped it) and how it was cleared.
- Filed #223 to add the server-side `post-merge-cleanup.yml` workflow (adapted for `ephemeral-npx`, mirroring #149's `idd-advisory-convergence.yml` adaptation) so future merges don't regrow the backlog.

## Why

- A `clean` `audit-pr-cleanup` result (no minimizable candidates) still needs its own evidence comment — the backlog check keys purely on comment presence, not on whether anything was actually minimized. Verified this empirically: PR #221's dry-run/apply reported `status=clean` with 0 candidates, yet it stayed in the backlog list until the evidence comment was posted.
- Applying cleanup mutates GitHub-visible state (comment minimization + new comments) across many historical PRs, so this was scoped as its own follow-up (#220) per its own acceptance criteria rather than run blind during #150's verification sweep.

## Verification

- `idd-doctor` (pinned `ephemeral-npx` spec) before: `post-merge cleanup backlog: 35 merged PRs in the last 14 days lack F4 cleanup evidence`.
- `idd-doctor` after: no backlog warning in `warnings` (only the 4 already-documented accepted-noise warnings remain: 2× `markdownlint-cli2` toolchain residue, `worktreeGuard` not wired locally, branch protection not readable).
- `npx markdownlint-cli2 "docs/idd-policy.md"` — 0 issues.
- `npx cspell docs/idd-policy.md` — 0 issues.

Closes #220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the IDD policy findings to show a passing result with four warnings and no errors.
  * Documented the resolution of the post-merge cleanup backlog and confirmed that no backlog pull requests currently remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->