### PR TITLE
feat(ci): add a server-side post-merge-cleanup workflow

### DIFF
--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,159 @@
+# Trust model: this workflow triggers on `pull_request_target`, which runs
+# with base-repository permissions and secrets even for pull requests from
+# forks. That is safe here only because all of the following hold, and any
+# future edit to this file must preserve them:
+#   - No unreviewed PR-head content is ever checked out: the sole
+#     `actions/checkout` step below carries no `ref:` override, so it
+#     resolves to the `pull_request_target` default -- the base branch's
+#     tip at event time. Because the job only proceeds when
+#     `merged == true`, that tip already includes this PR's own merge
+#     (this repository merges via merge commits, so it is typically that
+#     merge commit itself) -- it is never the PR's own head SHA, and
+#     never content that has not already passed through the merge
+#     decision.
+#   - No PR-head code, workflow, or action is ever executed: the only
+#     script that runs is the pinned `ephemeral-npx` `idd-audit-pr-cleanup`
+#     CLI (see docs/idd-policy.md "Helper Runtime Profile"), invoked with
+#     the PR number as inert numeric data (interpolated into a
+#     single-quoted shell variable, not evaluated).
+#   - The `cleanup` job only runs when
+#     `github.event.pull_request.merged == true`, or via an explicit,
+#     human-triggered `workflow_dispatch` -- never against an open or
+#     unmerged pull request.
+#   - `permissions:` stays least-privilege: `contents: read`,
+#     `issues: write`, `pull-requests: write` -- no `contents: write` and
+#     no elevated or secret-bearing scopes.
+# If a future change adds a `ref:` override on the checkout step, downloads
+# or executes PR-head content, widens `permissions:`, or removes the
+# merged-only guard, re-review this trust model before merging that change.
+#
+# Adapted from kurone-kito/idd-skill's
+# .github/workflows/post-merge-cleanup.yml at pin
+# 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d. This repository runs the
+# ephemeral-npx helper profile (no vendored scripts/ directory), so this
+# invokes the packaged idd-audit-pr-cleanup CLI rather than upstream's
+# `node scripts/audit-pr-cleanup.mjs` form. `runs-on` and the
+# checkout/setup-node steps follow this repository's own
+# idd-advisory-convergence.yml conventions rather than upstream's
+# ubuntu-slim + pinned-SHA choices, to stay consistent with how this
+# repository already runs its other npx+gh workflows.
+name: Post-merge cleanup
+on:
+  pull_request_target:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to clean up
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  group: post-merge-cleanup-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+jobs:
+  cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - name: Run F4 cleanup (server-side fallback)
+        id: cleanup
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          PR_NUMBER='${{ github.event.pull_request.number || github.event.inputs.pr_number }}'
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR_NUMBER is empty"
+            exit 1
+          fi
+          JSON=$(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
+            idd-audit-pr-cleanup \
+            --pr "$PR_NUMBER" \
+            --apply \
+            --skip-claim-check \
+            --format json 2>cleanup-stderr.log)
+          HELPER_EXIT=$?
+          set -e
+          # Prefer the helper's JSON report when it is parseable, even on
+          # non-zero exit (the helper writes the report then exits 1 when
+          # failed.length > 0, so the report is still authoritative).
+          PARSED_STATUS=""
+          if [ -n "$JSON" ]; then
+            PARSED_STATUS=$(printf '%s' "$JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+          fi
+          if [ -n "$PARSED_STATUS" ]; then
+            printf '%s\n' "$JSON" > cleanup-report.json
+            STATUS="$PARSED_STATUS"
+            APPLIED=$(printf '%s' "$JSON" | jq -r '(.applied // []) | length')
+            FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
+            SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
+            BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            if [ "$HELPER_EXIT" -ne 0 ]; then
+              echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
+            fi
+          else
+            echo "::warning::idd-audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON; posting helper-error evidence"
+            STATUS="helper-error"
+            APPLIED=0
+            FAILED=0
+            SKIPPED=0
+            BLOCKED=0
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "status=$STATUS"
+            echo "applied=$APPLIED"
+            echo "failed=$FAILED"
+            echo "skipped=$SKIPPED"
+            echo "blocked=$BLOCKED"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post cleanup evidence comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
+          STATUS: ${{ steps.cleanup.outputs.status }}
+          APPLIED: ${{ steps.cleanup.outputs.applied }}
+          FAILED: ${{ steps.cleanup.outputs.failed }}
+          SKIPPED: ${{ steps.cleanup.outputs.skipped }}
+          BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+        run: |
+          # Avoid duplicate evidence comments. Workflow-level concurrency
+          # only serialises this workflow's own runs; an agent F4 (or a
+          # maintainer rerunning workflow_dispatch on the same PR) can
+          # still have posted an evidence comment outside this run. Skip
+          # if any <!-- idd-cleanup-evidence: ... --> comment is already
+          # on the PR.
+          EXISTING=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id' \
+            | head -n1)
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${PR_NUMBER} already has an idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+            exit 0
+          fi
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+            "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+            "| Field              | Value |" \
+            "| ------------------ | ----- |" \
+            "| Status             | ${STATUS} |" \
+            "| Applied            | ${APPLIED} |" \
+            "| Failed             | ${FAILED} |" \
+            "| Skipped            | ${SKIPPED} |" \
+            "| Permission-blocked | ${BLOCKED} |" \
+            "| Posted by          | post-merge-cleanup workflow |" \
+          )
+          printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -3,40 +3,52 @@
 # forks. That is safe here only because all of the following hold, and any
 # future edit to this file must preserve them:
 #   - No unreviewed PR-head content is ever checked out: the sole
-#     `actions/checkout` step below carries no `ref:` override, so it
-#     resolves to the `pull_request_target` default -- the base branch's
-#     tip at event time. Because the job only proceeds when
+#     `actions/checkout` step below carries no `ref:` override. For the
+#     `pull_request_target` trigger this resolves to the base branch's
+#     tip at event time -- because the job only proceeds when
 #     `merged == true`, that tip already includes this PR's own merge
 #     (this repository merges via merge commits, so it is typically that
 #     merge commit itself) -- it is never the PR's own head SHA, and
 #     never content that has not already passed through the merge
-#     decision.
+#     decision. For `workflow_dispatch`, checkout instead resolves to
+#     whatever ref the dispatch targeted (the default branch, when
+#     dispatched from the Actions UI on that branch) -- this is not
+#     governed by the `pull_request_target` ref rule, but the checked-out
+#     code is never executed either way (see the next point), so this
+#     difference does not widen the trust boundary.
 #   - No PR-head code, workflow, or action is ever executed: the only
 #     script that runs is the pinned `ephemeral-npx` `idd-audit-pr-cleanup`
 #     CLI (see docs/idd-policy.md "Helper Runtime Profile"), invoked with
-#     the PR number as inert numeric data (interpolated into a
-#     single-quoted shell variable, not evaluated).
+#     the PR number passed through `env:` as inert numeric data, never
+#     interpolated into the script body.
 #   - The `cleanup` job only runs when
-#     `github.event.pull_request.merged == true`, or via an explicit,
-#     human-triggered `workflow_dispatch` -- never against an open or
-#     unmerged pull request.
+#     `github.event.pull_request.merged == true`; for `workflow_dispatch`
+#     (human-triggered, but not otherwise constrained by GitHub) the job
+#     additionally re-verifies via `gh pr view` that the given PR number
+#     is actually merged before invoking `--apply`, and refuses to run
+#     otherwise.
 #   - `permissions:` stays least-privilege: `contents: read`,
 #     `issues: write`, `pull-requests: write` -- no `contents: write` and
 #     no elevated or secret-bearing scopes.
 # If a future change adds a `ref:` override on the checkout step, downloads
 # or executes PR-head content, widens `permissions:`, or removes the
-# merged-only guard, re-review this trust model before merging that change.
+# merged-only guard (including the workflow_dispatch re-verification),
+# re-review this trust model before merging that change.
 #
 # Adapted from kurone-kito/idd-skill's
 # .github/workflows/post-merge-cleanup.yml at pin
 # 4e8c7043edcb00dd8447dee83e7a17e5b2604d5d. This repository runs the
 # ephemeral-npx helper profile (no vendored scripts/ directory), so this
 # invokes the packaged idd-audit-pr-cleanup CLI rather than upstream's
-# `node scripts/audit-pr-cleanup.mjs` form. `runs-on` and the
-# checkout/setup-node steps follow this repository's own
-# idd-advisory-convergence.yml conventions rather than upstream's
-# ubuntu-slim + pinned-SHA choices, to stay consistent with how this
-# repository already runs its other npx+gh workflows.
+# `node scripts/audit-pr-cleanup.mjs` form. `runs-on` follows this
+# repository's own idd-advisory-convergence.yml convention
+# (`ubuntu-latest`) rather than upstream's `ubuntu-slim`, since that is
+# the runner label this repository already uses for its other npx+gh
+# workflows (lint.yml and stale.yml use `ubuntu-slim` for actions-only
+# steps with no npx/gh dependency). The checkout/setup-node action pins
+# are copied verbatim from upstream's own pinned-SHA choices, since this
+# workflow's elevated `pull_request_target` permissions warrant the same
+# supply-chain hardening upstream already applied.
 name: Post-merge cleanup
 on:
   pull_request_target:
@@ -61,24 +73,35 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Run F4 cleanup (server-side fallback)
         id: cleanup
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
-          set +e
-          PR_NUMBER='${{ github.event.pull_request.number || github.event.inputs.pr_number }}'
           if [ -z "$PR_NUMBER" ]; then
             echo "::error::PR_NUMBER is empty"
             exit 1
           fi
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # workflow_dispatch is human-triggered but not otherwise
+            # constrained by GitHub to a merged PR, unlike the
+            # pull_request_target trigger's `if:` guard above. Re-verify
+            # directly rather than trusting the dispatch input.
+            MERGED=$(gh pr view "$PR_NUMBER" --json merged --jq '.merged' 2>/dev/null || echo "")
+            if [ "$MERGED" != "true" ]; then
+              echo "::error::PR #$PR_NUMBER is not merged; refusing to run cleanup for a manual dispatch against an unmerged PR"
+              exit 1
+            fi
+          fi
+          set +e
           JSON=$(npx --yes --package https://codeload.github.com/kurone-kito/idd-skill/tar.gz/4e8c7043edcb00dd8447dee83e7a17e5b2604d5d \
             idd-audit-pr-cleanup \
             --pr "$PR_NUMBER" \

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -136,10 +136,13 @@ jobs:
           # still have posted an evidence comment outside this run. Skip
           # if any <!-- idd-cleanup-evidence: ... --> comment is already
           # on the PR.
-          EXISTING=$(gh api --paginate \
+          ALL_MATCHES=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id' \
-            | head -n1)
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id')
+          # Capture first, then head; piping gh api directly into head can
+          # SIGPIPE gh once head exits early, which fails the pipeline
+          # under this shell's default `bash -eo pipefail`.
+          EXISTING=$(printf '%s\n' "$ALL_MATCHES" | head -n1)
           if [ -n "$EXISTING" ]; then
             echo "::notice::PR #${PR_NUMBER} already has an idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
             exit 0

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -194,6 +194,37 @@ reports an **enabled-but-inert** finding when `worktreeGuard.enabled`
 is `true` but `core.hooksPath` is not pointed at `.githooks`. Bypass
 the guard for a single intentional commit or push with `--no-verify`.
 
+## Post-Merge Cleanup Automation
+
+[`.github/workflows/post-merge-cleanup.yml`](../.github/workflows/post-merge-cleanup.yml)
+(#223) runs the F4 comment-cleanup step server-side on every merged PR,
+via a `pull_request_target: closed` trigger filtered to
+`merged == true` (or an explicit `workflow_dispatch`). It invokes the
+pinned `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply
+--skip-claim-check --format json` CLI and posts the same
+`<!-- idd-cleanup-evidence: ... -->` comment an agent's manual F4 step
+would, skipping the post when a prior evidence comment already exists.
+
+This backstops the manual, agent-run F4 step documented under
+[`idd-doctor` findings](#idd-doctor-findings): #220 found that most of
+one session's merges skipped F4 by hand, growing a 35-PR backlog before
+this workflow existed. With the workflow wired, every future merge
+gets cleanup evidence within minutes regardless of whether the merging
+agent ran F4 itself; the agent's own F4 step still runs first when
+present and simply finds nothing left to do (duplicate-success-record
+skip rule in
+[`docs/idd-comment-minimization.md`](idd-comment-minimization.md)).
+
+`runs-on: ubuntu-latest` and the `actions/checkout@v7` /
+`actions/setup-node@v4` steps follow this repository's own
+`idd-advisory-convergence.yml` conventions rather than upstream's
+`ubuntu-slim` + pinned-action-SHA choices, to stay consistent with how
+this repository already runs its other npx+gh workflows; the
+trust-model invariants that actually gate the elevated
+`pull_request_target` permissions (no `ref:` override, no PR-head
+execution, merged-only guard, least-privilege `permissions:`) are
+preserved verbatim from upstream.
+
 ## Advisory Bot Logins
 
 **`advisoryBotLogins`**: `["copilot-pull-request-reviewer[bot]",
@@ -356,9 +387,9 @@ rediscover them:
   `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue
   220 --claim-id <claim-id>` CLI against every flagged PR and posting
   the evidence comment by hand; `idd-doctor` now reports zero backlog
-  PRs. This does not prevent regrowth on future merges that skip F4;
-  issue #223 tracks adding the server-side `post-merge-cleanup.yml`
-  workflow upstream ships for the `vendored-node` profile, adapted for
+  PRs. #223 closed the regrowth gap by wiring the server-side
+  [`post-merge-cleanup.yml`](#post-merge-cleanup-automation) workflow,
+  adapted from upstream's `vendored-node`-profile original for
   `ephemeral-npx` the same way #149 adapted
   `idd-advisory-convergence.yml`.
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -199,11 +199,14 @@ the guard for a single intentional commit or push with `--no-verify`.
 [`.github/workflows/post-merge-cleanup.yml`](../.github/workflows/post-merge-cleanup.yml)
 (#223) runs the F4 comment-cleanup step server-side on every merged PR,
 via a `pull_request_target: closed` trigger filtered to
-`merged == true` (or an explicit `workflow_dispatch`). It invokes the
-pinned `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply
---skip-claim-check --format json` CLI and posts the same
-`<!-- idd-cleanup-evidence: ... -->` comment an agent's manual F4 step
-would, skipping the post when a prior evidence comment already exists.
+`merged == true` (or an explicit `workflow_dispatch`, additionally
+re-verified against `gh pr view` before it runs `--apply`, since the
+dispatch input itself is not otherwise constrained to a merged PR). It
+invokes the pinned `ephemeral-npx`
+`idd-audit-pr-cleanup --pr <N> --apply --skip-claim-check --format json`
+CLI and posts the same `<!-- idd-cleanup-evidence: ... -->` comment an
+agent's manual F4 step would, skipping the post when a prior evidence
+comment already exists.
 
 This backstops the manual, agent-run F4 step documented under
 [`idd-doctor` findings](#idd-doctor-findings): #220 found that most of
@@ -215,15 +218,18 @@ present and simply finds nothing left to do (duplicate-success-record
 skip rule in
 [`docs/idd-comment-minimization.md`](idd-comment-minimization.md)).
 
-`runs-on: ubuntu-latest` and the `actions/checkout@v7` /
-`actions/setup-node@v4` steps follow this repository's own
-`idd-advisory-convergence.yml` conventions rather than upstream's
-`ubuntu-slim` + pinned-action-SHA choices, to stay consistent with how
-this repository already runs its other npx+gh workflows; the
-trust-model invariants that actually gate the elevated
-`pull_request_target` permissions (no `ref:` override, no PR-head
-execution, merged-only guard, least-privilege `permissions:`) are
-preserved verbatim from upstream.
+`runs-on: ubuntu-latest` follows this repository's own
+`idd-advisory-convergence.yml` convention rather than upstream's
+`ubuntu-slim`, matching how this repository already runs its other
+npx+gh workflows. The `actions/checkout` / `actions/setup-node` steps
+keep upstream's pinned-commit-SHA choices rather than this repository's
+usual floating major-version tags, since this workflow's elevated
+`pull_request_target` permissions warrant the same supply-chain
+hardening upstream already applied. The trust-model invariants that
+actually gate those permissions (no `ref:` override, no PR-head
+execution, merged-only guard including the `workflow_dispatch`
+re-verification, least-privilege `permissions:`) are preserved from
+upstream.
 
 ## Advisory Bot Logins
 

--- a/docs/idd-policy.md
+++ b/docs/idd-policy.md
@@ -233,8 +233,8 @@ upstream.
 
 ## Advisory Bot Logins
 
-**`advisoryBotLogins`**: `["copilot-pull-request-reviewer[bot]",
-"coderabbitai[bot]"]`.
+**`advisoryBotLogins`**:
+`["copilot-pull-request-reviewer[bot]", "coderabbitai[bot]"]`.
 
 Both logins were confirmed against live review events on
 [PR #193](https://github.com/kurone-kito/dotfiles/pull/193), which
@@ -264,9 +264,9 @@ directory).
 ## CI Gate External Check Waivers
 
 **`ciGate.externalCheckWaivers.mode`**: `maintainer-authorized`.
-**`ciGate.externalChecks.waivable`**: `[{ "selector":
-"idd-advisory-convergence" }]`. **`authorityPolicy`** and
-**`maxValidity`** are left unset (distributed defaults
+**`ciGate.externalChecks.waivable`**:
+`[{ "selector": "idd-advisory-convergence" }]`. **`authorityPolicy`**
+and **`maxValidity`** are left unset (distributed defaults
 `owners-and-maintainers-only` and `PT24H`).
 
 This prepares the waiver path for roadmap #144's #149 (hosting the
@@ -365,9 +365,9 @@ rediscover them:
   false-positive pattern match against the pinned upstream commit's
   own toolchain, which happens to use the same tool, not a residual
   upstream-marker-prefix string. `idd-doctor`'s toolchain-residue
-  scanner has no per-finding waiver flag (confirmed via `idd-doctor
-  --help` while investigating #218), so this is accepted as permanent
-  noise rather than suppressed.
+  scanner has no per-finding waiver flag (confirmed via
+  `idd-doctor --help` while investigating #218), so this is accepted
+  as permanent noise rather than suppressed.
 - **`worktreeGuard.enabled` is true but `core.hooksPath` is unset in
   this environment**: expected on any fresh clone that has not yet run
   the wiring step documented in [Worktree Guard](#worktree-guard) --
@@ -390,10 +390,10 @@ rediscover them:
   step is a manual, agent-run part of the merge sequence with no
   server-side backstop, so most of this session's merges skipped it.
   #220 cleared the existing 35-PR backlog by running the pinned
-  `ephemeral-npx` `idd-audit-pr-cleanup --pr <N> --apply --claim-issue
-  220 --claim-id <claim-id>` CLI against every flagged PR and posting
-  the evidence comment by hand; `idd-doctor` now reports zero backlog
-  PRs. #223 closed the regrowth gap by wiring the server-side
+  `ephemeral-npx` `idd-audit-pr-cleanup` CLI in apply mode, under the
+  active claim, against every flagged PR, and posting the evidence
+  comment by hand; `idd-doctor` now reports zero backlog PRs. #223
+  closed the regrowth gap by wiring the server-side
   [`post-merge-cleanup.yml`](#post-merge-cleanup-automation) workflow,
   adapted from upstream's `vendored-node`-profile original for
   `ephemeral-npx` the same way #149 adapted


### PR DESCRIPTION
## Summary

- Add `.github/workflows/post-merge-cleanup.yml`: runs the F4 comment-cleanup step server-side on every merged PR (`pull_request_target: closed` filtered to `merged == true`, or an explicit `workflow_dispatch` re-verified against `gh pr view` before it applies), so future merges don't regrow the backlog #220 just cleared.
- Adapted from `kurone-kito/idd-skill`'s same-named workflow at the pinned commit for this repository's `ephemeral-npx` helper profile: invokes the packaged `idd-audit-pr-cleanup` CLI instead of upstream's `node scripts/audit-pr-cleanup.mjs` form.
- `runs-on: ubuntu-latest` follows this repository's own `idd-advisory-convergence.yml` convention rather than upstream's `ubuntu-slim`. `actions/checkout`/`actions/setup-node` keep upstream's pinned-commit-SHA choices (not this repository's usual floating tags), since this workflow's elevated `pull_request_target` permissions warrant the same supply-chain hardening upstream already applied.
- Documented the new automation in `docs/idd-policy.md` (new "Post-Merge Cleanup Automation" section) and updated the `idd-doctor` findings note that previously tracked this as open work in #223.

## Security note (`pull_request_target`)

This workflow runs with base-repository permissions/secrets even for fork PRs. Trust-model invariants, preserved from upstream:

- No `ref:` override on the sole `actions/checkout` step — for the `pull_request_target` trigger it resolves to the base branch's tip at event time (never the PR's own head SHA); for `workflow_dispatch` it resolves to whatever ref the dispatch targeted, which doesn't matter since checked-out code is never executed either way.
- No PR-head code, workflow, or action ever executes — the only script that runs is the pinned `ephemeral-npx` `idd-audit-pr-cleanup` CLI, invoked with the PR number passed through `env:` (not interpolated into the script body — see review fixes below).
- The `cleanup` job only runs when `merged == true`; for `workflow_dispatch` it additionally re-verifies via `gh pr view` that the given PR is actually merged before invoking `--apply`.
- `permissions:` stays least-privilege: `contents: read`, `issues: write`, `pull-requests: write` — no `contents: write`, no elevated scopes.
- `actions/checkout` and `actions/setup-node` are pinned to upstream's own verified commit SHAs (not this repository's usual floating `@v7`/`@v4` tags), since this workflow's elevated `pull_request_target` permissions warrant that supply-chain hardening.

## Review history

CodeRabbit (backed by zizmor) and Copilot found five real issues in the first draft, all fixed:

1. `workflow_dispatch` could run `--apply` against an unmerged PR number — added a `gh pr view` merge re-verification.
2. `actions/checkout`/`actions/setup-node` used floating tags despite the elevated permissions — pinned to upstream's SHAs.
3. Interpolating the PR-number expression directly into the `run:` script body is a template-injection pattern (zizmor `template-injection`) even though the values are always numeric today — moved into `env:`, referenced as `$PR_NUMBER`.
4. An inline code span in `docs/idd-policy.md` was split across a line break, breaking Markdown rendering — reflowed.
5. The trust-model comment inaccurately claimed checkout always resolves to the `pull_request_target` base-branch default — clarified the `workflow_dispatch` case separately.
6. (This PR description itself was stale after fix 2 — corrected above.)

## Verification

- `actionlint` (the new file alone and the full `.github/workflows/` tree): 0 issues.
- `npx markdownlint-cli2 "docs/idd-policy.md"` — 0 issues.
- `npx cspell docs/idd-policy.md .github/workflows/post-merge-cleanup.yml` — 0 issues.
- Not yet exercised end-to-end (no merge has landed since this workflow was added); the next merged PR after this one is the first live test. If it misbehaves, `workflow_dispatch` allows a manual re-run against any specific merged PR number for recovery.

Closes #223
