### PR TITLE
fix(ci): port upstream's concurrency hardening into idd-advisory-convergence.yml

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -63,6 +63,7 @@ words:
   - pylint
   - qwen
   - rerere
+  - rollup
   - sheerun
   - taskrc
   - TOCTOU

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -16,7 +16,7 @@ name: IDD advisory-convergence gate
 # added alongside pull_request. Several such events can fire in quick
 # succession during review triage (e.g. a batch of disposition
 # replies), so `concurrency:` below debounces them to at most one
-# active run per head SHA instead of several stacked ones -- this
+# active run per pull request instead of several stacked ones -- this
 # exact multi-run pattern is a documented, previously-investigated
 # upstream incident: kurone-kito/idd-skill#1381 (empirically
 # reproduced on that repository's own PR #1383; see that repository's
@@ -26,22 +26,22 @@ name: IDD advisory-convergence gate
 # `cancel-in-progress: true` does not fully close the gap: a stale
 # CANCELLED run can still race a later SUCCESS run for the identical
 # head SHA in the required-check rollup display. When that happens,
-# recover with `gh run rerun <run-id>` on the *specific* stuck run --
-# find it via `gh run list --workflow=idd-advisory-convergence.yml
-# --json databaseId,headSha,conclusion,createdAt` filtered to the
-# current head SHA, matching against `gh pr checks <pr-number>`'s
-# reported `completedAt` for this check. Do not assume the
-# most-recently-completed run among several for that SHA is the stuck
-# one -- if the match is unclear, rerun every run for that head SHA
-# rather than guessing (rerunning an already-successful run is a
-# harmless no-op). Use the plain whole-run `gh run rerun <run-id>`
-# form, not `--failed`: a stale CANCELLED run has no job with a
-# `failure` conclusion for `--failed` to retry, so it would silently
-# do nothing. `workflow_dispatch` does not reliably flip the rollup
-# for its own head SHA either (it has no `pull_request` context of its
-# own), so prefer rerunning an existing pull_request-family-triggered
-# run over dispatching a fresh one whenever one already exists for the
-# current head SHA.
+# recover with `gh run rerun <run-id>` on the run(s) for the current
+# head SHA -- find them via `gh run list
+# --workflow=idd-advisory-convergence.yml --limit 50 --json
+# databaseId,headSha,conclusion` filtered to that exact SHA (raise
+# `--limit` past its default of 20 on a busy PR). If more than one run
+# matches and it is unclear which one the rollup is stuck on, rerun all
+# of them rather than guessing -- rerunning an already-successful run
+# is safe (it just re-confirms the same result; it still consumes
+# runner time, so it is not literally a no-op). Use the plain
+# whole-run `gh run rerun <run-id>` form, not `--failed`: a stale
+# CANCELLED run has no job with a `failure` conclusion for `--failed`
+# to retry, so it would silently do nothing. `workflow_dispatch` does
+# not reliably flip the rollup for its own head SHA either (it has no
+# `pull_request` context of its own), so prefer rerunning an existing
+# pull_request-family-triggered run over dispatching a fresh one
+# whenever one already exists for the current head SHA.
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -8,6 +8,40 @@ name: IDD advisory-convergence gate
 # waiver escape is already configured in `.github/idd/config.json`
 # `ciGate.*`; see docs/idd-policy.md "CI Gate External Check Waivers"
 # for the waiver path.
+#
+# CI topology: convergence can change WITHOUT a new push -- when
+# Copilot submits its review (pull_request_review), or when a
+# disposition marker (or any other reply/edit/delete) is posted on a
+# review thread (pull_request_review_comment) -- so both triggers are
+# added alongside pull_request. Several such events can fire in quick
+# succession during review triage (e.g. a batch of disposition
+# replies), so `concurrency:` below debounces them to at most one
+# active run per head SHA instead of several stacked ones -- this
+# exact multi-run pattern is a documented, previously-investigated
+# upstream incident: kurone-kito/idd-skill#1381 (empirically
+# reproduced on that repository's own PR #1383; see that repository's
+# identically-pinned idd-advisory-convergence.yml header for the full
+# writeup) -- ported here after #226 hit the same friction without it.
+#
+# `cancel-in-progress: true` does not fully close the gap: a stale
+# CANCELLED run can still race a later SUCCESS run for the identical
+# head SHA in the required-check rollup display. When that happens,
+# recover with `gh run rerun <run-id>` on the *specific* stuck run --
+# find it via `gh run list --workflow=idd-advisory-convergence.yml
+# --json databaseId,headSha,conclusion,createdAt` filtered to the
+# current head SHA, matching against `gh pr checks <pr-number>`'s
+# reported `completedAt` for this check. Do not assume the
+# most-recently-completed run among several for that SHA is the stuck
+# one -- if the match is unclear, rerun every run for that head SHA
+# rather than guessing (rerunning an already-successful run is a
+# harmless no-op). Use the plain whole-run `gh run rerun <run-id>`
+# form, not `--failed`: a stale CANCELLED run has no job with a
+# `failure` conclusion for `--failed` to retry, so it would silently
+# do nothing. `workflow_dispatch` does not reliably flip the rollup
+# for its own head SHA either (it has no `pull_request` context of its
+# own), so prefer rerunning an existing pull_request-family-triggered
+# run over dispatching a fresh one whenever one already exists for the
+# current head SHA.
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -25,9 +59,18 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+concurrency:
+  cancel-in-progress: true
+  # Grouped by PR number, not github.ref: pull_request_review and
+  # pull_request_review_comment are not pull_request-family events, so
+  # github.ref does not resolve the same way for them as it does for a
+  # pull_request-only workflow. workflow_dispatch has no pull_request
+  # context either, so it falls back to its own inputs.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 jobs:
   idd-advisory-convergence:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

- Port upstream's `concurrency:` block into `.github/workflows/idd-advisory-convergence.yml`: `group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}`, `cancel-in-progress: true`.
- Add `timeout-minutes: 10` to the job, matching upstream.
- Add a condensed version of upstream's operational-recovery guidance (the CANCELLED-vs-SUCCESS rollup race, the exact `gh run rerun <run-id>` recovery procedure, and the `--failed`/`workflow_dispatch` pitfalls) to the header comment, so a future session doesn't have to rediscover it from scratch.

## Why

Both PR #224 and PR #225 this session hit the exact same friction: several `pull_request_review_comment` events fired in quick succession during review triage produced multiple separate `idd-advisory-convergence` runs for one head SHA, none of which the required-check rollup would accept until each was individually found (`gh run list --workflow=idd-advisory-convergence.yml --json databaseId,headSha,conclusion`) and reran.

This turned out to be a documented, previously-investigated upstream incident (`kurone-kito/idd-skill#1381`, empirically reproduced on that repository's own PR #1383) — upstream's own identically-pinned `idd-advisory-convergence.yml` already carries the fix and an extensive writeup. Comparing our file (adapted for #149 at the same pin) against upstream's showed we never carried over the `concurrency:` block, `timeout-minutes:`, or the guidance comment. Filed as #226 during a retrospective on this session, and now fixed.

## Verification

- `actionlint .github/workflows/idd-advisory-convergence.yml` (and the full `.github/workflows/` tree) — 0 issues.
- Checked `docs/idd-policy.md` for anything that would need updating as a result — nothing does, since this change doesn't alter what the check asserts, only which duplicate runs get cancelled versus left stacked.
- Not yet exercised end-to-end against a live rapid-fire-comment scenario (hard to force deterministically); the next PR that triggers several quick review-triage replies is the natural live test.

Closes #226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Reduced duplicate validation runs triggered by rapid successive pull request review events.
  * Automatically cancels outdated in-progress runs for the same pull request context.
  * Added guidance for recovering from cancelled or stale workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->